### PR TITLE
feat: 빌드 스킴에 따라 CoreData 저장소 코드 분기, Dummy 데이터 생성 코드 구현

### DIFF
--- a/Media.xcodeproj/project.pbxproj
+++ b/Media.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		C714D8EC2DF434B800E601E9 /* TSAlertController in Frameworks */ = {isa = PBXBuildFile; productRef = C714D8EB2DF434B800E601E9 /* TSAlertController */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		C702131C2DF131F0007037B7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C714D8EC2DF434B800E601E9 /* TSAlertController in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,6 +75,7 @@
 			children = (
 				C70213042DF131EF007037B7 /* Media */,
 				C702131E2DF131F0007037B7 /* MediaTests */,
+				C714D8EA2DF434B800E601E9 /* Frameworks */,
 				C70213032DF131EF007037B7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -81,6 +87,13 @@
 				C702131B2DF131F0007037B7 /* MediaTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C714D8EA2DF434B800E601E9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -103,6 +116,7 @@
 			);
 			name = Media;
 			packageProductDependencies = (
+				C714D8EB2DF434B800E601E9 /* TSAlertController */,
 			);
 			productName = Media;
 			productReference = C70213022DF131EF007037B7 /* Media.app */;
@@ -159,6 +173,9 @@
 			);
 			mainGroup = C70212F92DF131EF007037B7;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				C714D8E92DF4348100E601E9 /* XCRemoteSwiftPackageReference "TSAlertController-iOS" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C70213032DF131EF007037B7 /* Products */;
 			projectDirPath = "";
@@ -470,6 +487,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C714D8E92DF4348100E601E9 /* XCRemoteSwiftPackageReference "TSAlertController-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rlarjsdn3/TSAlertController-iOS.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C714D8EB2DF434B800E601E9 /* TSAlertController */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C714D8E92DF4348100E601E9 /* XCRemoteSwiftPackageReference "TSAlertController-iOS" */;
+			productName = TSAlertController;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C70212FA2DF131EF007037B7 /* Project object */;
 }

--- a/Media.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Media.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f1d7d312160ece9ce8d1551b2fcaa9511f1bc3479a03e42546777d14ed414286",
+  "pins" : [
+    {
+      "identity" : "tsalertcontroller-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rlarjsdn3/TSAlertController-iOS.git",
+      "state" : {
+        "revision" : "3f13cf9f0cb879052cf87d8687f717e204846bde",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Media/Application/AppDelegate.swift
+++ b/Media/Application/AppDelegate.swift
@@ -17,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        
+        #if DEBUG
+        CoreDataService.shared.generateDummy()
+        #endif
+        
         return true
     }
 

--- a/Media/Core/NibView.swift
+++ b/Media/Core/NibView.swift
@@ -1,0 +1,25 @@
+//
+//  NibView.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import UIKit
+
+class NibView: UIView, NibLodable {
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+        setupAttributes()
+    }
+
+    /// UI 요소들을 뷰 계층에 추가합니다.
+    func setupUI() {
+    }
+
+    /// 뷰의 속성(색상, 폰트 등)을 설정합니다.
+    func setupAttributes() {
+    }
+}

--- a/Media/Core/Protocols/Alertable.swift
+++ b/Media/Core/Protocols/Alertable.swift
@@ -12,11 +12,17 @@ import TSAlertController
 protocol Alertable { }
 
 extension Alertable where Self: UIViewController {
-
+    
+    /// 사용자에게 확인 및 취소 옵션이 있는 기본 알림을 표시합니다.
+    /// - Parameters:
+    ///   - title: 알림창의 제목 텍스트
+    ///   - message: 알림창에 표시할 메시지 내용
+    ///   - onConfirm: 확인 버튼을 눌렀을 때 실행될 핸들러
+    ///   - onCancel: 취소 버튼을 눌렀을 때 실행될 핸들러
     func showAlert(
         _ title: String,
         message: String,
-        onConfirm: @escaping ((TSAlertAction)) -> Void,
+        onConfirm: @escaping (TSAlertAction) -> Void,
         onCancel: @escaping (TSAlertAction) -> Void
     ) {
         let alertController = defaultAlertController(title, message: message)
@@ -31,7 +37,13 @@ extension Alertable where Self: UIViewController {
 
         present(alertController, animated: true)
     }
-
+    
+    /// 사용자가 삭제 작업을 수행할 수 있도록 확인/취소 알림창을 표시합니다.
+    /// - Parameters:
+    ///   - title: 알림창의 제목 텍스트
+    ///   - message: 알림창에 표시할 메시지 내용
+    ///   - onConfirm: 삭제 버튼을 눌렀을 때 실행될 핸들러
+    ///   - onCancel: 취소 버튼을 눌렀을 때 실행될 핸들러
     func showDeleteAlert(
         _ title: String,
         message: String,
@@ -49,7 +61,14 @@ extension Alertable where Self: UIViewController {
 
         present(alertController, animated: true)
     }
-
+    
+    /// 텍스트 필드가 포함된 알림창을 표시합니다. 사용자의 입력과 확인/취소 동작을 처리할 수 있습니다.
+    /// - Parameters:
+    ///   - title: 알림창의 제목 텍스트
+    ///   - message: 알림창에 표시할 메시지 내용
+    ///   - placeholder: 텍스트 필드에 표시할 플레이스홀더 문자열 (옵션)
+    ///   - onConfirm: 확인 버튼을 눌렀을 때 실행될 핸들러. 사용자 입력값이 함께 전달됩니다.
+    ///   - onCancel: 취소 버튼을 눌렀을 때 실행될 핸들러
     func showTextFieldAlert(
         _ title: String,
         message: String,
@@ -77,11 +96,20 @@ extension Alertable where Self: UIViewController {
         present(alertController, animated: true)
     }
 
-    private func defaultAlertController(_ title: String, message: String) -> TSAlertController {
+
+    /// 기본 설정이 적용된 알림 컨트롤러를 생성합니다.
+    /// - Parameters:
+    ///   - title: 알림창의 제목 텍스트
+    ///   - message: 알림창에 표시할 메시지 내용
+    /// - Returns: 기본 애니메이션 및 옵션이 적용된 `TSAlertController` 인스턴스
+    private func defaultAlertController(
+        _ title: String,
+        message: String
+    ) -> TSAlertController {
         let alertController = TSAlertController(
             title: title,
             message: message,
-            options: [.dismissOnSwipeDown, .dismissOnTapOutside],
+            options: [.dismissOnSwipeDown, .interactiveScaleAndDrag],
             preferredStyle: .alert
         )
         alertController.configuration.enteringTransition = .slideUp

--- a/Media/Core/Protocols/Alertable.swift
+++ b/Media/Core/Protocols/Alertable.swift
@@ -116,6 +116,13 @@ extension Alertable where Self: UIViewController {
         alertController.configuration.exitingTransition = .slideDown
         alertController.configuration.headerAnimation = .slideUp
         alertController.configuration.buttonGroupAnimation = .slideUp
+
+        if traitCollection.horizontalSizeClass == .regular {
+            alertController.viewConfiguration.size = .init(
+                width: .proportional(minimumRatio: 0.4, maximumRatio: 0.8),
+                height: .proportional()
+            )
+        }
         return alertController
     }
 }

--- a/Media/Core/Protocols/Alertable.swift
+++ b/Media/Core/Protocols/Alertable.swift
@@ -1,0 +1,93 @@
+//
+//  Alertable.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import UIKit
+
+import TSAlertController
+
+protocol Alertable { }
+
+extension Alertable where Self: UIViewController {
+
+    func showAlert(
+        _ title: String,
+        message: String,
+        onConfirm: @escaping ((TSAlertAction)) -> Void,
+        onCancel: @escaping (TSAlertAction) -> Void
+    ) {
+        let alertController = defaultAlertController(title, message: message)
+
+        let okAction = TSAlertAction(title: "확인", style: .default, handler: onConfirm)
+        okAction.configuration.backgroundColor = UIColor.systemBlue // 임시 색상
+        okAction.configuration.titleAttributes?[.foregroundColor] = UIColor.systemBackground
+        alertController.addAction(okAction)
+
+        let cancelAction = TSAlertAction(title: "취소", style: .cancel, handler: onCancel)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true)
+    }
+
+    func showDeleteAlert(
+        _ title: String,
+        message: String,
+        onConfirm: @escaping (TSAlertAction) -> Void,
+        onCancel: @escaping (TSAlertAction) -> Void
+    ) {
+        let alertController = defaultAlertController(title, message: message)
+
+        let okAction = TSAlertAction(title: "삭제", style: .destructive, handler: onConfirm)
+        okAction.configuration.titleAttributes?[.foregroundColor] = UIColor.systemBackground
+        alertController.addAction(okAction)
+
+        let cancelAction = TSAlertAction(title: "취소", style: .cancel, handler: onCancel)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true)
+    }
+
+    func showTextFieldAlert(
+        _ title: String,
+        message: String,
+        placeholder: String? = nil,
+        onConfirm: @escaping ((TSAlertAction, String)) -> Void,
+        onCancel: @escaping (TSAlertAction) -> Void
+    ) {
+        let alertController = defaultAlertController(title, message: message)
+
+        alertController.addTextField {
+            $0.placeholder = placeholder
+        }
+
+        let okAction = TSAlertAction(title: "확인", style: .default) { action in
+            onConfirm((action, alertController.textFields?.first?.text ?? ""))
+        }
+        okAction.configuration.backgroundColor = UIColor.systemBlue // 임시 색상
+        okAction.configuration.titleAttributes?[.foregroundColor] = UIColor.systemBackground
+        alertController.addAction(okAction)
+        alertController.preferredAction = okAction
+
+        let cancelAction = TSAlertAction(title: "취소", style: .cancel, handler: onCancel)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true)
+    }
+
+    private func defaultAlertController(_ title: String, message: String) -> TSAlertController {
+        let alertController = TSAlertController(
+            title: title,
+            message: message,
+            options: [.dismissOnSwipeDown, .dismissOnTapOutside],
+            preferredStyle: .alert
+        )
+        alertController.configuration.enteringTransition = .slideUp
+        alertController.configuration.exitingTransition = .slideDown
+        alertController.configuration.headerAnimation = .slideUp
+        alertController.configuration.buttonGroupAnimation = .slideUp
+        return alertController
+    }
+}

--- a/Media/Core/StoryboardViewController.swift
+++ b/Media/Core/StoryboardViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class StoryboardViewController: UIViewController, StoryboardInstantiable {
+class StoryboardViewController: UIViewController, StoryboardInstantiable, Alertable {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Media/Infrastructure/Storage/CoreData/CoreDataError.swift
+++ b/Media/Infrastructure/Storage/CoreData/CoreDataError.swift
@@ -1,0 +1,21 @@
+//
+//  CoreDataError.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+
+/// Core Data 작업 중 발생할 수 있는 오류를 나타내는 열거형입니다.
+enum CoreDataError: Error {
+
+    /// 데이터를 읽는 도중 발생한 오류
+    case readError(any Error)
+
+    /// 데이터를 저장하는 도중 발생한 오류
+    case saveError(any Error)
+
+    /// 데이터를 삭제하는 도중 발생한 오류
+    case deleteError(any Error)
+}

--- a/Media/Infrastructure/Storage/CoreData/CoreDataService+Dummy.swift
+++ b/Media/Infrastructure/Storage/CoreData/CoreDataService+Dummy.swift
@@ -1,0 +1,19 @@
+//
+//  CoreDataService+Dummy.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+
+extension CoreDataService {
+    
+    /// 디버그 모드에서 (모든 기존 데이터를 삭제하고) 더미 데이터를 생성합니다.
+    func generateDummy() {
+        #if DEBUG
+        TodoEntity.mock(insertInto: viewContext)
+        #endif
+    }
+    
+}

--- a/Media/Model/CoreData/Media.xcdatamodeld/Media.xcdatamodel/contents
+++ b/Media/Model/CoreData/Media.xcdatamodeld/Media.xcdatamodel/contents
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="TodoEntity" representedClassName="TodoEntity" syncable="YES">
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/Media/Model/CoreData/TodoEntity+Convenience.swift
+++ b/Media/Model/CoreData/TodoEntity+Convenience.swift
@@ -1,0 +1,20 @@
+//
+//  TodoEntity+Convenience.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+import CoreData
+
+extension TodoEntity {
+    
+    convenience init(
+        title: String,
+        insertInto context: NSManagedObjectContext
+    ) {
+        self.init(context: context)
+        self.title = title
+    }
+}

--- a/Media/Model/CoreData/TodoEntity+CoreDataClass.swift
+++ b/Media/Model/CoreData/TodoEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  TodoEntity+CoreDataClass.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(TodoEntity)
+public class TodoEntity: NSManagedObject {
+
+}

--- a/Media/Model/CoreData/TodoEntity+CoreDataProperties.swift
+++ b/Media/Model/CoreData/TodoEntity+CoreDataProperties.swift
@@ -1,0 +1,25 @@
+//
+//  TodoEntity+CoreDataProperties.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension TodoEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TodoEntity> {
+        return NSFetchRequest<TodoEntity>(entityName: "TodoEntity")
+    }
+
+    @NSManaged public var title: String?
+
+}
+
+extension TodoEntity : Identifiable {
+
+}

--- a/Media/Model/CoreData/TodoEntity+Dummy.swift
+++ b/Media/Model/CoreData/TodoEntity+Dummy.swift
@@ -1,0 +1,16 @@
+//
+//  Todo+Dummy.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+import CoreData
+
+extension TodoEntity {
+
+    static func mock(insertInto context: NSManagedObjectContext) {
+        TodoResponse.mock.forEach { TodoEntity(title: $0.title, insertInto: context) }
+    }
+}

--- a/Media/Model/Response/Todo+Mock.swift
+++ b/Media/Model/Response/Todo+Mock.swift
@@ -1,0 +1,19 @@
+//
+//  TodoResponse+Mock.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+
+extension TodoResponse {
+    
+    static let mock: [TodoResponse] = [
+        .init(title: "Test1"),
+        .init(title: "Test2"),
+        .init(title: "Test3"),
+        .init(title: "Test4"),
+        .init(title: "Test5")
+    ]
+}

--- a/Media/Model/Response/TodoResponse.swift
+++ b/Media/Model/Response/TodoResponse.swift
@@ -1,0 +1,12 @@
+//
+//  TodoResponse.swift
+//  Media
+//
+//  Created by 김건우 on 6/7/25.
+//
+
+import Foundation
+
+struct TodoResponse {
+    let title: String
+}


### PR DESCRIPTION
## #️⃣ Related Issues

close #5 
close #9 

## 📝 Task Details

### 빌드 스킴에 따라 CoreData 저장소 코드 분기, Dummy 데이터 생성 코드 구현

* 빌드 스킴(scheme)에 따라 코어 데이터가 어느 방식으로 데이터를 저장하는지 코드 분기 처리 (디버그: in-memory, 릴리즈: on-disk)
```swift
/// 빌드 모드에 따라 in-memory 여부를 설정하는 초기화 메서드입니다.
/// - Note: 디버그 모드에서는 in-memory 저장소를 사용하고, 릴리즈 모드에서는 디스크에 영구 저장합니다.
private convenience init() {
     #if DEBUG
     self.init(inMemory: true)  // 디버그 모드: 메모리 전용 저장소 (테스트용)
     #else
     self.init(inMemory: false) // 릴리즈 모드: 실제 디스크에 저장
     #endif
 }
```

* 빌드 스킴이 `DEBUG` 모드라면, 더미 데이터가 들어가도록 generateDummy() 메서드 구현, AppDelegate에 적용
```swift
 extension CoreDataService {
     /// 디버그 모드에서 (모든 기존 데이터를 삭제하고) 더미 데이터를 생성합니다.
     func generateDummy() {
         #if DEBUG
         TodoEntity.mock(insertInto: viewContext)
         #endif
     }
 }
```


### `Alertable` 프로토콜 구현, TSAlertController 의존성 추가

* UIViewController에서 아래 메서드를 호출하면 적절한 알림창을 띄우기 가능

```swift
showAlert("네트워크 연결", message: "인터넷 연결이 불안정합니다. 계속하시겠습니까?") { _ in
    // ...
} onCancel: { _ in
    // ...
}

showDeleteAlert("삭제 확인", message: "삭제된 항목은 복구할 수 없습니다. 정말로 삭제하시겠습니까?") { _ in
    // ...
} onCancel: { _ in
    // ...
}

showTextFieldAlert("재생목록 추가", message: "재생목록 이름을 입력하세요.") { (_, text) in
    // ...
} onCancel: { _ in
    // ...
}
```

| showAlert | showDeleteAlert | showTextFieldAlert |
| :-: | :-: | :-: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-07 at 22 17 53](https://github.com/user-attachments/assets/8cf5b985-a5fb-4672-9cc9-0a73cdf6f552) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-07 at 22 24 54](https://github.com/user-attachments/assets/721b8987-9faf-465a-98bd-c199fe1094c7) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-07 at 22 15 26](https://github.com/user-attachments/assets/8189cfa2-96d0-4cdd-b159-7eb68a21c20d) |





