### PR TITLE
fix: 네비게이션 바 - 한쪽 버튼을 눌렀을 때 양쪽 버튼이 모두 사라지는 문제 해결

### DIFF
--- a/Media/Core/Common/NavigationBar/NavigationBar.swift
+++ b/Media/Core/Common/NavigationBar/NavigationBar.swift
@@ -158,21 +158,25 @@ class NavigationBar: NibView {
 }
 
 extension NavigationBar {
+    /// 오른쪽 버튼을 시각적으로 숨기고 터치 이벤트를 비활성화
     func hideRightButton() {
         rightButton.alpha = 0
         rightButton.isUserInteractionEnabled = false
     }
     
+    /// 오른쪽 버튼을 다시 보이게 하고 터치 이벤트를 활성화
     func showRightButton() {
         rightButton.alpha = 1
         rightButton.isUserInteractionEnabled = true
     }
     
+    /// 왼쪽 버튼을 시각적으로 숨기고 터치 이벤트를 비활성화
     func hideLeftButton() {
         leftButton.alpha = 0
         leftButton.isUserInteractionEnabled = false
     }
     
+    /// 왼쪽 버튼을 다시 보이게 하고 터치 이벤트를 활성화
     func showLeftButton() {
         leftButton.alpha = 1
         leftButton.isUserInteractionEnabled = true

--- a/Media/Core/Common/NavigationBar/NavigationBar.swift
+++ b/Media/Core/Common/NavigationBar/NavigationBar.swift
@@ -98,9 +98,6 @@ class NavigationBar: NibView {
         leftButton.tintColor = leftIconTint
         rightButton.tintColor = rightIconTint
         
-        leftButton.isHidden = (leftIcon == nil)
-        rightButton.isHidden = (rightIcon == nil)
-        
         // 검색 모드인 경우
         if isSearchMode {
             searchBarContainerView.isHidden = false
@@ -115,6 +112,9 @@ class NavigationBar: NibView {
             return
         }
 
+        leftButton.isHidden = (leftIcon == nil)
+        rightButton.isHidden = (rightIcon == nil)
+        
         // 타이틀 모드인 경우
         searchBarContainerView.isHidden = true
         titleStackView.isHidden = false
@@ -154,5 +154,27 @@ class NavigationBar: NibView {
     /// 오른쪽 버튼이 눌렸을 때 delegate에 이벤트 전달
     @objc private func rightTapped(_ sender: Any) {
         delegate?.navigationBarDidTapRight?(self)
+    }
+}
+
+extension NavigationBar {
+    func hideRightButton() {
+        rightButton.alpha = 0
+        rightButton.isUserInteractionEnabled = false
+    }
+    
+    func showRightButton() {
+        rightButton.alpha = 1
+        rightButton.isUserInteractionEnabled = true
+    }
+    
+    func hideLeftButton() {
+        leftButton.alpha = 0
+        leftButton.isUserInteractionEnabled = false
+    }
+    
+    func showLeftButton() {
+        leftButton.alpha = 1
+        leftButton.isUserInteractionEnabled = true
     }
 }

--- a/Media/Core/Common/NavigationBar/NavigationBar.xib
+++ b/Media/Core/Common/NavigationBar/NavigationBar.xib
@@ -29,7 +29,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mnw-Y8-peK">
                     <rect key="frame" x="16" y="59" width="361" height="44"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oCq-2v-9Ye">
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oCq-2v-9Ye">
                             <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="24" id="MI5-NR-LhW"/>
@@ -38,7 +38,7 @@
                             <state key="normal" title="Button"/>
                             <buttonConfiguration key="configuration" style="plain"/>
                         </button>
-                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="JDx-wX-MeL" userLabel="Center Container View">
+                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JDx-wX-MeL" userLabel="Center Container View">
                             <rect key="frame" x="32" y="0.0" width="297" height="44"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="kXI-Si-QXX" userLabel="Title Stack View">
@@ -87,7 +87,7 @@
                                 <constraint firstItem="kXI-Si-QXX" firstAttribute="centerX" secondItem="JDx-wX-MeL" secondAttribute="centerX" priority="750" id="rjS-u5-ALx"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qAm-jW-axf">
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qAm-jW-axf">
                             <rect key="frame" x="337" y="10" width="24" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="73j-4e-qB2"/>


### PR DESCRIPTION
## #️⃣ Related Issues

close #73 

## 📝 Task Details
- 레이아웃은 유지하면서 버튼만 시각적으로 숨기고 비활성화되도록 변경
상황에 따라 버튼을 보이게 / 숨기게 만들고 싶을 때 해당 `ViewController`에서 아래 메서드 실행
 - `hideRightButton()`
 - `showRightButton()`
 - `hideLeftButton()`
 - `showLeftButton()`
 - 사용 예시:
    ```Swift
    // 오른쪽 버튼을 숨기고 왼쪽 버튼은 보이게 함
    navigationBar.hideRightButton()
    navigationBar.showLeftButton()
    ```

+ 라벨이 버튼을 덮을 경우를 대비해 버튼의 hugging priority(Horizontal)도 high로 수정

