### PR TITLE
feat: 북마크 및 재생 기록 상세 보기 화면에서 네비게이션 바, 셀 컨텐츠, 레이아웃 수치 등 UI 수정

### DIFF
--- a/Media/Core/Extensions/UIViewController+Extension.swift
+++ b/Media/Core/Extensions/UIViewController+Extension.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AVKit
 
 extension UIViewController {
 

--- a/Media/Core/Protocols/VideoPlayable.swift
+++ b/Media/Core/Protocols/VideoPlayable.swift
@@ -1,0 +1,102 @@
+//
+//  VideoPlayable.swift
+//  Media
+//
+//  Created by 김건우 on 6/13/25.
+//
+
+import UIKit
+import AVKit
+
+/// 비디오를 재생할 수 있는 기능을 정의하는 프로토콜입니다.
+protocol VideoPlayable: AnyObject {
+
+    /// AVPlayerItem의 상태를 감시하기 위한 KVO 옵저버입니다.
+    var observation: NSKeyValueObservation? { get set }
+}
+
+extension VideoPlayable where Self: UIViewController {
+
+    /// 주어진 URL의 비디오를 재생합니다.
+    ///
+    /// 이 메서드는 URL을 기반으로 AVPlayer를 구성하고, AVPlayerViewController를 생성하여 화면에 표시합니다.
+    /// AVPlayerItem의 상태를 관찰하여 재생 준비가 완료되면 자동으로 재생을 시작하며,
+    /// 실패한 경우 콘솔에 오류 메시지를 출력합니다.
+    ///
+    /// - Parameter url: 재생할 비디오의 원격 또는 로컬 URL입니다.
+    func playVideo(from url: URL) {
+        observation?.invalidate()
+
+        let player = AVPlayer(url: url)
+        let vc = AVPlayerViewController()
+        vc.player = player
+
+        self.observation = player.currentItem?.observe(\.status, options: [.new]) { playerItem, _ in
+            switch playerItem.status {
+            case .readyToPlay:
+                player.play()
+            case .failed:
+                print("PlayerItem failed to load: \(playerItem.error?.localizedDescription ?? "Unknown error")")
+            default:
+                break
+            }
+        }
+
+        self.present(vc, animated: true) {
+            print("PlayerViewController presented")
+        }
+    }
+
+    /// 지정된 URL의 비디오를 다운로드하여 캐시한 후 재생합니다.
+    ///
+    /// 이 메서드는 비디오 URL을 기반으로 파일을 캐시한 뒤, AVPlayer를 통해 비디오를 재생합니다.
+    /// AVPlayerItem의 상태를 관찰하여 재생 가능 여부를 확인하고,
+    /// 재생 준비가 완료되면 자동으로 재생이 시작됩니다.
+    ///
+    /// - Note: 이 메서드는 아직 완전히 구현되지 않았으며, 사용이 권장되지 않습니다. 향후 구현 예정입니다.
+    ///
+    /// - Parameters:
+    ///   - url: 재생할 비디오의 원본 URL입니다.
+    ///   - cacher: 비디오를 다운로드하고 캐시하는 데 사용할 캐싱 객체입니다. 기본값은 `DefaultVideoCacher`입니다.
+    /// - Returns: 다운로드 작업을 취소할 수 있는 객체를 반환합니다. 이미 캐시된 경우에는 `nil`을 반환합니다.
+    @available(*, deprecated, message: "Not yet implemented")
+    @discardableResult
+    func playVideo(
+        with url: URL,
+        using cacher: any VideoCacher = DefaultVideoCacher()
+    ) -> (any NetworkCancellable)? {
+
+        observation?.invalidate()
+
+        return cacher.download(from: url) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let localUrl):
+                let item = AVPlayerItem(url: localUrl)
+                let player = AVPlayer(playerItem: item)
+                let vc = AVPlayerViewController()
+                vc.player = player
+
+                self.observation = player.observe(\.status, options: [.new]) { playerItem, _ in
+                    switch playerItem.status {
+                    case .readyToPlay:
+                        player.play()
+                    case .failed:
+                        print("PlayerItem failed to load: \(playerItem.error?.localizedDescription ?? "Unknown error")")
+                    default:
+                        break
+                    }
+                }
+
+                self.present(vc, animated: true) {
+                    print("PlayerViewController presented")
+                }
+
+
+            case .failure(let error):
+                print("PlayerItem failed to load: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Media/Infrastructure/DataTransfer/Endpoint/Requestable.swift
+++ b/Media/Infrastructure/DataTransfer/Endpoint/Requestable.swift
@@ -57,6 +57,7 @@ extension Requestable {
             guard let url = URL(string: baseUrl) else {
                 throw RequestGenerationError.components
             }
+            return url
         }
 
         //

--- a/Media/Infrastructure/Storage/CoreData/CoreDataService+Dummy.swift
+++ b/Media/Infrastructure/Storage/CoreData/CoreDataService+Dummy.swift
@@ -37,9 +37,10 @@ extension CoreDataService {
     private func generatePlaylistEntity() -> [PlaylistEntity] {
         let names = ["북마크를 표시한 재생목록", "재생목록1", "재생목록2", "재생목록3"]
 
-        let playlists: [PlaylistEntity] = names.map {
+        let playlists: [PlaylistEntity] = names.enumerated().map { index, name in
             let playlist = PlaylistEntity(context: self.viewContext)
-            playlist.name = $0
+            playlist.name = name
+            playlist.isBookmark = (index == 0)
             playlist.createdAt = Date().addingTimeInterval(86_400 * Double.random(in: -10...0))
             PixabayResponse.mock.hits.map {
                 let video = $0.mapToPlaylistVideoEntity(insertInto: self.viewContext)

--- a/Media/Presentation/Bookmark/BookmarkViewController.swift
+++ b/Media/Presentation/Bookmark/BookmarkViewController.swift
@@ -44,9 +44,12 @@ final class BookmarkViewController: StoryboardViewController {
                       let playlistVideos = playlistEntity.playlistVideos?.allObjects as? [PlaylistVideoEntity] else {
                     return
                 }
-                playlistVC.videos = playlistEntity.isBookmark
-                ? .playlist(title: playlistEntity.name, entities: playlistVideos, isBookmark: true)
-                : .playlist(title: playlistEntity.name, entities: playlistVideos, isBookmark: false)
+
+                playlistVC.videos = .playlist(
+                    title: playlistEntity.name,
+                    entities: playlistVideos,
+                    isBookmark: playlistEntity.isBookmark
+                )
 
             } else {
                 guard let playbackVideos = playbackFetchedResultsController?.fetchedObjects else { return }

--- a/Media/Presentation/Bookmark/BookmarkViewController.swift
+++ b/Media/Presentation/Bookmark/BookmarkViewController.swift
@@ -8,9 +8,11 @@
 import UIKit
 import CoreData
 
-final class BookmarkViewController: StoryboardViewController {
+final class BookmarkViewController: StoryboardViewController, VideoPlayable {
 
     private typealias BookmarkDiffableDataSource = UICollectionViewDiffableDataSource<Bookmark.Section, Bookmark.Item>
+
+    var observation: NSKeyValueObservation? = nil
 
     private let userDefaultsService = UserDefaultsService.shared
     private let coreDataService = CoreDataService.shared
@@ -24,9 +26,9 @@ final class BookmarkViewController: StoryboardViewController {
     private var playlistFetchedResultsController: NSFetchedResultsController<PlaylistEntity>? = nil
     private var playlistVideoFetchedResultsController: NSFetchedResultsController<PlaylistVideoEntity>? = nil
 
-    
+
     // MARK: - Lifecycles
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -132,6 +134,10 @@ extension BookmarkViewController {
                     tags: playback.tags
 
                 )
+                cell.onThumbnailTap = { [weak self] in
+                    guard let url = playback.video?.medium.url else { return }
+                    self?.playVideo(from: url)
+                }
                 cell.configure(with: viewModel)
             }
         }
@@ -152,7 +158,7 @@ extension BookmarkViewController {
                         userName: playlist.name,
                         total: totalVideos
                     )
-                // 대표 이미지가 없다면 이미지를 빼고 재생 목록 셀 구성
+                    // 대표 이미지가 없다면 이미지를 빼고 재생 목록 셀 구성
                 } else {
                     viewModel = PlayListViewModel(
                         userName: playlist.name,
@@ -197,10 +203,10 @@ extension BookmarkViewController {
     private func appendPlaybackItems(to snapshot: inout NSDiffableDataSourceSnapshot<Bookmark.Section, Bookmark.Item>) {
         guard let playback = playbackFetchedResultsController?.fetchedObjects,
               !playback.isEmpty else { return }
-        let items = playback.map { Bookmark.Item.playback($0) }
+        let items = playback.map { Bookmark.Item.playback($0) }.prefix(10)
         let section = Bookmark.Section(type: .playback)
         snapshot.appendSections([section])
-        snapshot.appendItems(items, toSection: section)
+        snapshot.appendItems(Array(items), toSection: section)
     }
 
     private func appendPlaylistItems(to snapshot: inout NSDiffableDataSourceSnapshot<Bookmark.Section, Bookmark.Item>) {
@@ -247,7 +253,7 @@ extension BookmarkViewController {
             cacheName: nil
         )
         playlistVideoFetchedResultsController?.delegate = self
-        
+
         do {
             try playlistFetchedResultsController?.performFetch()
             try playbackFetchedResultsController?.performFetch()
@@ -317,11 +323,11 @@ extension BookmarkViewController: UICollectionViewDelegate {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        guard let item = self.dataSource?.itemIdentifier(for: indexPath) else { return }
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }
 
         switch item {
         case .playback:
-            break // TODO: - 셀을 클릭하면 비디오가 출력되도록 코드 수정
+            break
         case .playlist:
             performSegue(
                 withIdentifier: "navigateToPlaylistVideos",
@@ -381,7 +387,7 @@ extension BookmarkViewController: HeaderButtonDelegate {
 // MARK: - Extension
 
 extension BookmarkViewController {
-    
+
     private func showAddPlaylistAlert() {
 
         showTextFieldAlert(
@@ -396,7 +402,7 @@ extension BookmarkViewController {
                 } else {
                     Toast.makeToast("이미 존재하는 재생 목록 이름입니다.").present()
                 }
-        } onCancel: { _ in }
+            } onCancel: { _ in }
     }
 
     private func renamePlaylistAction(for indexPath: IndexPath) -> UIAction {

--- a/Media/Presentation/Bookmark/Section/BookmarkSection.swift
+++ b/Media/Presentation/Bookmark/Section/BookmarkSection.swift
@@ -36,9 +36,9 @@ enum Bookmark {
         func hash(into hasher: inout Hasher) {
             switch self {
             case .playback(let entity):
-                hasher.combine(entity.objectID)
+                hasher.combine(entity.id)
             case .playlist(let entity):
-                hasher.combine(entity.objectID)
+                hasher.combine(entity.id)
             case .addPlaylist:
                 hasher.combine("addPlaylist")
             }
@@ -47,9 +47,9 @@ enum Bookmark {
         static func == (lhs: Item, rhs: Item) -> Bool {
             switch (lhs, rhs) {
             case (.playback(let a), .playback(let b)):
-                return a.objectID == b.objectID
+                return a.id == b.id
             case (.playlist(let a), .playlist(let b)):
-                return a.objectID == b.objectID
+                return a.id == b.id
             case (.addPlaylist, .addPlaylist):
                 return true
             default:
@@ -92,7 +92,7 @@ extension Bookmark.SectionType {
             subitems: [item]
         )
         group.interItemSpacing = .flexible(10)
-        group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 20, trailing: 0)
+        group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 20, trailing: 0)
 
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),

--- a/Media/Presentation/Bookmark/Section/VideoListSection.swift
+++ b/Media/Presentation/Bookmark/Section/VideoListSection.swift
@@ -49,18 +49,18 @@ enum VideoList {
         func hash(into hasher: inout Hasher) {
             switch self {
             case .playlist(let entity):
-                hasher.combine(entity.objectID)
+                hasher.combine(entity.id)
             case .playback(let entity):
-                hasher.combine(entity.objectID)
+                hasher.combine(entity.id)
             }
         }
 
         static func == (lhs: Item, rhs: Item) -> Bool {
             switch (lhs, rhs) {
             case (.playlist(let a), .playlist(let b)):
-                return a.objectID == b.objectID
+                return a.id == b.id
             case (.playback(let a), .playback(let b)):
-                return a.objectID == b.objectID
+                return a.id == b.id
             default:
                 return false
             }

--- a/Media/Presentation/Bookmark/VideoListViewController.swift
+++ b/Media/Presentation/Bookmark/VideoListViewController.swift
@@ -149,15 +149,22 @@ final class VideoListViewController: StoryboardViewController {
     private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
         let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { [weak self] sectionIndex, environment in
 
-            let itemWidthDimension: NSCollectionLayoutDimension = environment.isHorizontalSizeClassCompact
-            ? .fractionalWidth(1.0) : .fractionalWidth(0.33)
+            let itemWidthDimension: NSCollectionLayoutDimension = switch environment.container.effectiveContentSize.width {
+            case ..<500:      .fractionalWidth(1.0)  // 아이폰 세로모드
+            case 500..<1000:  .fractionalWidth(0.5)  // 아이패드 세로 모드
+            default:          .fractionalWidth(0.33) // 아이패드 가로 모드
+            }
             let itemSize = NSCollectionLayoutSize(
-                widthDimension: itemWidthDimension, // 임시 값
-                heightDimension: .absolute(100) // 임시 값
+                widthDimension: itemWidthDimension,
+                heightDimension: .absolute(100)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-            let columnCount = environment.isHorizontalSizeClassCompact ? 1 : 3
+            let columnCount = switch environment.container.effectiveContentSize.width {
+            case ..<500:      1 // 아이폰 세로모드
+            case 500..<1000:  2 // 아이패드 세로 모드
+            default:          3 // 아이패드 가로 모드
+            }
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0), // 임시 값
                 heightDimension: .absolute(100) // 임시 값
@@ -167,10 +174,12 @@ final class VideoListViewController: StoryboardViewController {
                 repeatingSubitem: item,
                 count: columnCount
             )
-            group.interItemSpacing = .flexible(8) // 임시 값
+            group.interItemSpacing = .fixed(8) // 임시 값
+            group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
 
             let section = NSCollectionLayoutSection(group: group)
             section.interGroupSpacing = 8 // 임시 값
+            section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
 
             if case .playback(_) = self?.videos {
                 let headerSize = NSCollectionLayoutSize(
@@ -263,6 +272,8 @@ extension VideoListViewController {
 
             if case let .playlist(_, _, isBookmark) = self?.videos {
                 cell.isBookMark = isBookmark
+            } else {
+                cell.isBookMark = false
             }
         }
     }

--- a/Media/Presentation/Bookmark/VideoListViewController.swift
+++ b/Media/Presentation/Bookmark/VideoListViewController.swift
@@ -166,19 +166,19 @@ final class VideoListViewController: StoryboardViewController {
             default:          3 // 아이패드 가로 모드
             }
             let groupSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0), // 임시 값
-                heightDimension: .absolute(100) // 임시 값
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(100)
             )
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
                 repeatingSubitem: item,
                 count: columnCount
             )
-            group.interItemSpacing = .fixed(8) // 임시 값
+            group.interItemSpacing = .fixed(8)
             group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
 
             let section = NSCollectionLayoutSection(group: group)
-            section.interGroupSpacing = 8 // 임시 값
+            section.interGroupSpacing = 8 
             section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
 
             if case .playback(_) = self?.videos {

--- a/Media/Presentation/Bookmark/VideoListViewController.swift
+++ b/Media/Presentation/Bookmark/VideoListViewController.swift
@@ -82,14 +82,16 @@ final class VideoListViewController: StoryboardViewController {
                 rightIcon: rightIcon,
                 rightIconTint: .systemRed
             )
+            navigationBar.hideRightButton()
         case let .playlist(title, _, _):
             navigationBar.configure(
                 title: title,
                 leftIcon: leftIcon,
                 leftIconTint: .mainLabelColor,
-                rightIcon: rightIcon, // rightIcon이 없으면 버튼이 표시 x
+                rightIcon: rightIcon,
                 rightIconTint: .systemRed
             )
+            navigationBar.hideRightButton()
         default:
             break
         }

--- a/Media/Presentation/Bookmark/VideoListViewController.swift
+++ b/Media/Presentation/Bookmark/VideoListViewController.swift
@@ -17,12 +17,14 @@ enum VideoListType {
 
 }
 
-final class VideoListViewController: StoryboardViewController {
+final class VideoListViewController: StoryboardViewController, VideoPlayable {
 
     typealias PlaylistDiffableDataSource = UICollectionViewDiffableDataSource<VideoList.Section, VideoList.Item>
 
     var videos: VideoListType?
+    var observation: NSKeyValueObservation?
     private let coreDataService = CoreDataService.shared
+    private let videoCacher = DefaultVideoCacher()
 
     private var dataSource: PlaylistDiffableDataSource? = nil
 
@@ -414,6 +416,17 @@ extension VideoListViewController: UICollectionViewDelegate {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }
+
+        if case let .playback(entity) = item,
+           let videoUrl = entity.video?.medium.url {
+            playVideo(from: videoUrl)
+        }
+
+        if case let .playlist(entity) = item,
+           let videoUrl = entity.video?.medium.url{
+            playVideo(from: videoUrl)
+        }
     }
     
     func collectionView(

--- a/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.swift
+++ b/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.swift
@@ -52,7 +52,7 @@ class MediumVideoCell: UICollectionViewCell, NibLodable, UIContextMenuInteractio
                 .setImage(
                     isBookMark
                     ? UIImage(systemName: "bookmark.fill")
-                    : UIImage(systemName: "trash.fill"),
+                    : UIImage(systemName: "trash"),
                     for: .normal
                 )
             actionButton.tintColor = isBookMark ? .label: .systemRed
@@ -88,7 +88,7 @@ class MediumVideoCell: UICollectionViewCell, NibLodable, UIContextMenuInteractio
         thumbnailImageView.layer.cornerRadius = 8
         paddingLabel.layer.cornerRadius = 3
 
-        let destruct = UIAction(title: "전체 삭제", attributes: .destructive) { _ in
+        let destruct = UIAction(title: "전체 삭제", image: UIImage(systemName: "trash"), attributes: .destructive) { _ in
             print("전체 삭제")
         }
 

--- a/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.swift
+++ b/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.swift
@@ -20,7 +20,8 @@ class MediumVideoCell: UICollectionViewCell, NibLodable, UIContextMenuInteractio
                 )
     }
     
-
+    @IBOutlet weak var containerView: UIView!
+    
     /// 썸네일 이미지를 표시하는 뷰
     @IBOutlet private weak var thumbnailImageView: UIImageView!
 
@@ -48,13 +49,15 @@ class MediumVideoCell: UICollectionViewCell, NibLodable, UIContextMenuInteractio
     /// 북마크 여부
     var isBookMark: Bool = false {
         didSet {
-            actionButton
-                .setImage(
-                    isBookMark
-                    ? UIImage(systemName: "bookmark.fill")
-                    : UIImage(systemName: "trash"),
-                    for: .normal
-                )
+            let config = UIImage.SymbolConfiguration(pointSize: 12)
+            let image = if isBookMark {
+                UIImage(systemName: "bookmark.fill")?
+                    .withConfiguration(config)
+            } else {
+                UIImage(systemName: "trash")?
+                    .withConfiguration(config)
+            }
+            actionButton.setImage(image, for: .normal)
             actionButton.tintColor = isBookMark ? .label: .systemRed
         }
     }
@@ -92,11 +95,13 @@ class MediumVideoCell: UICollectionViewCell, NibLodable, UIContextMenuInteractio
             print("전체 삭제")
         }
 
-
+        containerView.backgroundColor = .systemBackground
+        containerView.layer.cornerRadius = 12
+        containerView.layer.masksToBounds = true
     }
 
     func configureMenu(deleteAction: @escaping () -> Void) {
-        let destruct = UIAction(title: "전체 삭제", attributes: .destructive) { _ in
+        let destruct = UIAction(title: "전체 삭제", image: UIImage(systemName: "trash"), attributes: .destructive) { _ in
             deleteAction()
         }
         let interaction = UIContextMenuInteraction(delegate: self)
@@ -112,7 +117,7 @@ extension MediumVideoCell {
     func configure(_ history: MediumVideoViewModel) {
         currentThumbnailURL = history.thumbnailUrl
         configureThumbnail(from: history.thumbnailUrl)
-        tagsLabel.text = history.tags
+        tagsLabel.text = history.tags.split(by: ",").prefix(2).joined(separator: ", ")
         userNameLabel.text = history.userName
         durationLabel.text = formatDuration(history.duration)
         let numberFormatter = NumberFormatter()

--- a/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.xib
+++ b/Media/Presentation/Bookmark/View/Cells/MediumVideoCell.xib
@@ -13,125 +13,138 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="" id="gTV-IL-0wX" customClass="MediumVideoCell" customModule="Media" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="415" height="97"/>
+            <rect key="frame" x="0.0" y="0.0" width="430" height="125"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="415" height="97"/>
+                <rect key="frame" x="0.0" y="0.0" width="430" height="125"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q5f-4o-SgE">
-                        <rect key="frame" x="0.0" y="0.0" width="415" height="97"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vZZ-pt-UOZ">
+                        <rect key="frame" x="0.0" y="0.0" width="430" height="125"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="MLV-PE-d9P">
-                                <rect key="frame" x="0.0" y="0.0" width="385" height="97"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q5f-4o-SgE">
+                                <rect key="frame" x="8" y="8" width="414" height="109"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LT1-lR-vKU">
-                                        <rect key="frame" x="0.0" y="1.6666666666666643" width="185" height="94"/>
-                                    </imageView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w73-i0-xhW">
-                                        <rect key="frame" x="200" y="0.0" width="185" height="97"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="MLV-PE-d9P">
+                                        <rect key="frame" x="0.0" y="0.0" width="389" height="109"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="flower, yellow, blossom, bee, insect, bee" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqf-pO-Axe">
-                                                <rect key="frame" x="0.0" y="0.0" width="185" height="64.666666666666671"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="cIi-2k-O0W">
-                                                <rect key="frame" x="0.0" y="72" width="136" height="18"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LT1-lR-vKU">
+                                                <rect key="frame" x="0.0" y="0.0" width="187" height="109"/>
+                                            </imageView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w73-i0-xhW">
+                                                <rect key="frame" x="202" y="0.0" width="187" height="109"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UserName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="krd-54-2bl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="59.666666666666664" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                        <color key="textColor" systemColor="systemGray2Color"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="flower, yellow, blossom, bee, insect, bee" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqf-pO-Axe">
+                                                        <rect key="frame" x="0.0" y="6" width="187" height="64.666666666666671"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="•" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nqc-kP-GOp">
-                                                        <rect key="frame" x="64.666666666666686" y="0.0" width="5.6666666666666714" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                        <color key="textColor" systemColor="systemGray2Color"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Z5-Eg-gaB">
-                                                        <rect key="frame" x="75.333333333333314" y="0.0" width="38.666666666666657" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <color key="textColor" systemColor="systemGray2Color"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="111" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VFQ-fP-2y8">
-                                                        <rect key="frame" x="119" y="0.0" width="17" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                        <color key="textColor" systemColor="systemGray2Color"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="cIi-2k-O0W">
+                                                        <rect key="frame" x="0.0" y="83" width="136" height="18"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UserName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="krd-54-2bl">
+                                                                <rect key="frame" x="0.0" y="0.0" width="59.666666666666664" height="18"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                <color key="textColor" systemColor="systemGray2Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="•" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nqc-kP-GOp">
+                                                                <rect key="frame" x="64.666666666666686" y="0.0" width="5.6666666666666714" height="18"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                <color key="textColor" systemColor="systemGray2Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Z5-Eg-gaB">
+                                                                <rect key="frame" x="75.333333333333314" y="0.0" width="38.666666666666657" height="18"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <color key="textColor" systemColor="systemGray2Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="111" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VFQ-fP-2y8">
+                                                                <rect key="frame" x="119" y="0.0" width="17" height="18"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                <color key="textColor" systemColor="systemGray2Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
-                                            </stackView>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="cIi-2k-O0W" secondAttribute="bottom" constant="8" id="F7Z-vq-kX1"/>
+                                                    <constraint firstAttribute="trailing" secondItem="tqf-pO-Axe" secondAttribute="trailing" id="IF1-8l-Ra6"/>
+                                                    <constraint firstItem="cIi-2k-O0W" firstAttribute="leading" secondItem="tqf-pO-Axe" secondAttribute="leading" id="Xm2-it-Cpf"/>
+                                                    <constraint firstItem="tqf-pO-Axe" firstAttribute="top" secondItem="w73-i0-xhW" secondAttribute="top" constant="6" id="cS6-xA-FkM"/>
+                                                    <constraint firstItem="tqf-pO-Axe" firstAttribute="leading" secondItem="w73-i0-xhW" secondAttribute="leading" id="ojw-mt-ppV"/>
+                                                </constraints>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="tqf-pO-Axe" secondAttribute="trailing" id="IF1-8l-Ra6"/>
-                                            <constraint firstItem="cIi-2k-O0W" firstAttribute="leading" secondItem="tqf-pO-Axe" secondAttribute="leading" id="Xm2-it-Cpf"/>
-                                            <constraint firstItem="tqf-pO-Axe" firstAttribute="top" secondItem="w73-i0-xhW" secondAttribute="top" id="cS6-xA-FkM"/>
-                                            <constraint firstItem="cIi-2k-O0W" firstAttribute="top" secondItem="tqf-pO-Axe" secondAttribute="bottom" constant="7.3333333333333286" id="eWD-ns-KmE"/>
-                                            <constraint firstItem="tqf-pO-Axe" firstAttribute="leading" secondItem="w73-i0-xhW" secondAttribute="leading" id="ojw-mt-ppV"/>
-                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-x8-w6s">
+                                        <rect key="frame" x="143" y="84.333333333333329" width="36" height="16.666666666666671"/>
+                                        <color key="backgroundColor" name="TagSelected"/>
                                     </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-9R-c2T">
+                                        <rect key="frame" x="147.33333333333334" y="86.666666666666671" width="27.333333333333343" height="12"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="10"/>
+                                        <color key="textColor" name="Background"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hse-VH-0vs">
+                                        <rect key="frame" x="389" y="6" width="25" height="25"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="25" id="1au-qG-cbT"/>
+                                            <constraint firstAttribute="width" constant="25" id="IGR-Qq-ap4"/>
+                                        </constraints>
+                                        <color key="tintColor" systemColor="systemRedColor"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" imagePadding="5">
+                                            <imageReference key="image" image="trash" catalog="system" symbolScale="small"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="buttonDidTap:" destination="gTV-IL-0wX" eventType="touchUpInside" id="bvj-r8-KTy"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                            </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hse-VH-0vs">
-                                <rect key="frame" x="385" y="0.0" width="30" height="22"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="30" id="IGR-Qq-ap4"/>
-                                    <constraint firstAttribute="width" secondItem="hse-VH-0vs" secondAttribute="height" multiplier="15:11" id="o17-XA-J47"/>
+                                    <constraint firstItem="fCF-9R-c2T" firstAttribute="centerY" secondItem="2EQ-x8-w6s" secondAttribute="centerY" id="5I6-m2-UYo"/>
+                                    <constraint firstAttribute="bottom" secondItem="MLV-PE-d9P" secondAttribute="bottom" id="9zY-IX-L7Y"/>
+                                    <constraint firstItem="fCF-9R-c2T" firstAttribute="height" secondItem="2EQ-x8-w6s" secondAttribute="height" multiplier="0.72619" id="AV7-Fs-ekD"/>
+                                    <constraint firstItem="2EQ-x8-w6s" firstAttribute="trailing" secondItem="LT1-lR-vKU" secondAttribute="trailing" constant="-8" id="Ej5-9M-Uay"/>
+                                    <constraint firstItem="MLV-PE-d9P" firstAttribute="leading" secondItem="q5f-4o-SgE" secondAttribute="leading" id="Md9-OE-XhN"/>
+                                    <constraint firstAttribute="trailing" secondItem="hse-VH-0vs" secondAttribute="trailing" id="Nlt-8D-jVT"/>
+                                    <constraint firstItem="2EQ-x8-w6s" firstAttribute="bottom" secondItem="LT1-lR-vKU" secondAttribute="bottom" constant="-8" id="NxK-7o-t18"/>
+                                    <constraint firstItem="hse-VH-0vs" firstAttribute="top" secondItem="q5f-4o-SgE" secondAttribute="top" constant="6" id="Qoe-zu-Gad"/>
+                                    <constraint firstItem="MLV-PE-d9P" firstAttribute="top" secondItem="q5f-4o-SgE" secondAttribute="top" id="Qpw-L7-NuP"/>
+                                    <constraint firstItem="fCF-9R-c2T" firstAttribute="width" secondItem="2EQ-x8-w6s" secondAttribute="width" multiplier="0.760234" id="cDy-f0-Ydr"/>
+                                    <constraint firstItem="fCF-9R-c2T" firstAttribute="centerX" secondItem="2EQ-x8-w6s" secondAttribute="centerX" id="kRD-00-NY8"/>
+                                    <constraint firstItem="MLV-PE-d9P" firstAttribute="trailing" secondItem="hse-VH-0vs" secondAttribute="leading" id="kiL-rZ-2aF"/>
                                 </constraints>
-                                <color key="tintColor" systemColor="systemRedColor"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" imagePadding="5">
-                                    <imageReference key="image" image="trash" catalog="system" symbolScale="small"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="buttonDidTap:" destination="gTV-IL-0wX" eventType="touchUpInside" id="bvj-r8-KTy"/>
-                                </connections>
-                            </button>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EQ-x8-w6s">
-                                <rect key="frame" x="141" y="72.333333333333329" width="36" height="16.666666666666671"/>
-                                <color key="backgroundColor" name="TagSelected"/>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fCF-9R-c2T">
-                                <rect key="frame" x="145.33333333333334" y="74.666666666666671" width="27.333333333333343" height="12"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="10"/>
-                                <color key="textColor" name="Background"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="fCF-9R-c2T" firstAttribute="centerY" secondItem="2EQ-x8-w6s" secondAttribute="centerY" id="5I6-m2-UYo"/>
-                            <constraint firstItem="hse-VH-0vs" firstAttribute="top" secondItem="q5f-4o-SgE" secondAttribute="top" id="9lg-gT-XLb"/>
-                            <constraint firstAttribute="bottom" secondItem="MLV-PE-d9P" secondAttribute="bottom" id="9zY-IX-L7Y"/>
-                            <constraint firstItem="fCF-9R-c2T" firstAttribute="height" secondItem="2EQ-x8-w6s" secondAttribute="height" multiplier="0.72619" id="AV7-Fs-ekD"/>
-                            <constraint firstItem="2EQ-x8-w6s" firstAttribute="trailing" secondItem="LT1-lR-vKU" secondAttribute="trailing" constant="-8" id="Ej5-9M-Uay"/>
-                            <constraint firstItem="MLV-PE-d9P" firstAttribute="leading" secondItem="q5f-4o-SgE" secondAttribute="leading" id="Md9-OE-XhN"/>
-                            <constraint firstAttribute="trailing" secondItem="hse-VH-0vs" secondAttribute="trailing" id="Nlt-8D-jVT"/>
-                            <constraint firstItem="2EQ-x8-w6s" firstAttribute="bottom" secondItem="LT1-lR-vKU" secondAttribute="bottom" constant="-8" id="NxK-7o-t18"/>
-                            <constraint firstItem="MLV-PE-d9P" firstAttribute="top" secondItem="q5f-4o-SgE" secondAttribute="top" id="Qpw-L7-NuP"/>
-                            <constraint firstItem="fCF-9R-c2T" firstAttribute="width" secondItem="2EQ-x8-w6s" secondAttribute="width" multiplier="0.760234" id="cDy-f0-Ydr"/>
-                            <constraint firstItem="fCF-9R-c2T" firstAttribute="centerX" secondItem="2EQ-x8-w6s" secondAttribute="centerX" id="kRD-00-NY8"/>
-                            <constraint firstItem="MLV-PE-d9P" firstAttribute="trailing" secondItem="hse-VH-0vs" secondAttribute="leading" id="kiL-rZ-2aF"/>
+                            <constraint firstAttribute="bottom" secondItem="q5f-4o-SgE" secondAttribute="bottom" constant="8" id="CS2-Xe-gjQ"/>
+                            <constraint firstItem="q5f-4o-SgE" firstAttribute="top" secondItem="vZZ-pt-UOZ" secondAttribute="top" constant="8" id="MYC-9p-msZ"/>
+                            <constraint firstAttribute="trailing" secondItem="q5f-4o-SgE" secondAttribute="trailing" constant="8" id="c3d-DY-Nyl"/>
+                            <constraint firstItem="q5f-4o-SgE" firstAttribute="leading" secondItem="vZZ-pt-UOZ" secondAttribute="leading" constant="8" id="uPL-cd-IKn"/>
                         </constraints>
                     </view>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstItem="q5f-4o-SgE" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="Sdn-bG-L4g"/>
-                <constraint firstItem="q5f-4o-SgE" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="oGj-RQ-jQK"/>
-                <constraint firstAttribute="trailing" secondItem="q5f-4o-SgE" secondAttribute="trailing" id="q4e-3o-cgV"/>
-                <constraint firstAttribute="bottom" secondItem="q5f-4o-SgE" secondAttribute="bottom" id="rtG-Yn-EoZ"/>
+                <constraint firstItem="vZZ-pt-UOZ" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="1YM-nG-5F7"/>
+                <constraint firstAttribute="trailing" secondItem="vZZ-pt-UOZ" secondAttribute="trailing" id="Klr-4m-k2w"/>
+                <constraint firstAttribute="bottom" secondItem="vZZ-pt-UOZ" secondAttribute="bottom" id="UdL-Rc-S0M"/>
+                <constraint firstItem="vZZ-pt-UOZ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="XUJ-wb-VqO"/>
             </constraints>
-            <size key="customSize" width="415" height="97"/>
+            <size key="customSize" width="430" height="125"/>
             <connections>
                 <outlet property="actionButton" destination="hse-VH-0vs" id="6od-Co-dmA"/>
+                <outlet property="containerView" destination="vZZ-pt-UOZ" id="zoq-uj-AwH"/>
                 <outlet property="durationLabel" destination="fCF-9R-c2T" id="AdN-rQ-aPa"/>
                 <outlet property="paddingLabel" destination="2EQ-x8-w6s" id="ysS-3f-0h4"/>
                 <outlet property="tagsLabel" destination="tqf-pO-Axe" id="5Dg-xy-Mek"/>
@@ -139,7 +152,7 @@
                 <outlet property="userNameLabel" destination="krd-54-2bl" id="aHz-P1-gkp"/>
                 <outlet property="viewsCountLabel" destination="VFQ-fP-2y8" id="F6P-PM-PKb"/>
             </connections>
-            <point key="canvasLocation" x="205.34351145038167" y="52.464788732394368"/>
+            <point key="canvasLocation" x="216.79389312977099" y="62.323943661971832"/>
         </collectionViewCell>
     </objects>
     <resources>
@@ -154,10 +167,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray2Color">
-            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Media/Presentation/Home/VideoCell/VideoCell.swift
+++ b/Media/Presentation/Home/VideoCell/VideoCell.swift
@@ -35,7 +35,7 @@ final class VideoCell: UICollectionViewCell, NibLodable {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        thumbnailImage.contentMode = .scaleAspectFit
+        thumbnailImage.contentMode = .scaleAspectFill
         thumbnailImage.clipsToBounds = true
 
         profileImage.contentMode = .scaleAspectFill

--- a/Media/Presentation/Home/VideoCell/VideoCell.xib
+++ b/Media/Presentation/Home/VideoCell/VideoCell.xib
@@ -18,24 +18,21 @@
                 <rect key="frame" x="0.0" y="0.0" width="349" height="301"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qus-iH-a3n">
-                        <rect key="frame" x="0.0" y="0.0" width="349" height="196.33333333333334"/>
-                        <constraints>
-                            <constraint firstAttribute="width" secondItem="Qus-iH-a3n" secondAttribute="height" multiplier="16:9" id="rvJ-Qh-6um"/>
-                        </constraints>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qus-iH-a3n">
+                        <rect key="frame" x="0.0" y="0.0" width="349" height="228.66666666666666"/>
                     </imageView>
-                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vhj-7R-C3L">
-                        <rect key="frame" x="0.0" y="196.33333333333334" width="349" height="104.66666666666666"/>
+                    <view contentMode="scaleToFill" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vhj-7R-C3L">
+                        <rect key="frame" x="0.0" y="228.66666666666666" width="349" height="72.333333333333343"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rum-U0-kE6">
-                                <rect key="frame" x="8" y="32.333333333333314" width="40" height="40"/>
+                                <rect key="frame" x="8" y="16" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="40" id="3dA-6X-bCo"/>
                                     <constraint firstAttribute="height" constant="40" id="f2Y-1v-FUl"/>
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="esD-UN-lo5">
-                                <rect key="frame" x="317" y="40.333333333333314" width="24" height="24"/>
+                                <rect key="frame" x="317" y="24" width="24" height="24"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="BaE-8T-nh4"/>
@@ -51,13 +48,13 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="NSF-rt-wH9">
-                                <rect key="frame" x="56.000000000000014" y="14.666666666666657" width="153.33333333333337" height="75.333333333333329"/>
+                                <rect key="frame" x="56.000000000000014" y="13.666666666666686" width="164.33333333333337" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" axis="vertical" distribution="fillProportionally" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="esk-Jq-zY4">
-                                        <rect key="frame" x="0.0" y="0.0" width="153.33333333333334" height="20.333333333333332"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="164.33333333333334" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9lP-ev-7ue">
-                                                <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -65,19 +62,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="bzm-g5-ouh"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vAK-Yn-RVR">
-                                        <rect key="frame" x="0.0" y="25.333333333333343" width="153.33333333333334" height="50"/>
+                                        <rect key="frame" x="0.0" y="24.999999999999972" width="164.33333333333334" height="20"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7YE-q1-shH">
-                                                <rect key="frame" x="0.0" y="0.0" width="73.666666666666671" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7YE-q1-shH">
+                                                <rect key="frame" x="0.0" y="0.0" width="78.666666666666671" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="play.rectangle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="xa5-F6-aqd">
-                                                        <rect key="frame" x="0.0" y="1.6666666666666643" width="23.666666666666668" height="47"/>
+                                                        <rect key="frame" x="0.0" y="1.6666666666666643" width="23.666666666666668" height="17.000000000000004"/>
                                                         <color key="tintColor" name="SubLabel"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ota-XM-3Mw">
-                                                        <rect key="frame" x="23.666666666666671" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="28.666666666666671" y="0.0" width="50" height="20"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -86,15 +86,15 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mcf-2q-oBD">
-                                                <rect key="frame" x="83.666666666666657" y="0.0" width="69.666666666666657" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="mcf-2q-oBD">
+                                                <rect key="frame" x="88.666666666666657" y="0.0" width="75.666666666666657" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hand.thumbsup" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="mTU-xM-UW5">
-                                                        <rect key="frame" x="0.0" y="-0.33333333333333215" width="19.666666666666668" height="50"/>
+                                                        <rect key="frame" x="0.0" y="-0.33333333333333215" width="19.666666666666668" height="20"/>
                                                         <color key="tintColor" name="SubLabel"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oa5-Yp-m8P">
-                                                        <rect key="frame" x="19.666666666666686" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="25.666666666666686" y="0.0" width="50" height="20"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -104,12 +104,16 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="YsU-wt-RAx"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstAttribute="height" constant="72.5" id="2Kc-Id-RX7"/>
                             <constraint firstItem="NSF-rt-wH9" firstAttribute="leading" secondItem="rum-U0-kE6" secondAttribute="trailing" constant="8" id="5t1-PZ-bBh"/>
                             <constraint firstItem="esD-UN-lo5" firstAttribute="centerY" secondItem="Vhj-7R-C3L" secondAttribute="centerY" id="EJu-x8-U4N"/>
                             <constraint firstItem="rum-U0-kE6" firstAttribute="centerY" secondItem="Vhj-7R-C3L" secondAttribute="centerY" id="PL4-0W-1yT"/>
@@ -119,7 +123,7 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPG-8s-UiA">
-                        <rect key="frame" x="312.33333333333331" y="175" width="28.666666666666686" height="13.333333333333343"/>
+                        <rect key="frame" x="312.33333333333331" y="207.33333333333334" width="28.666666666666686" height="13.333333333333343"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.05399659863945578" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -127,7 +131,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WqS-NL-D4v">
-                        <rect key="frame" x="8" y="172.66666666666666" width="33" height="15.666666666666657"/>
+                        <rect key="frame" x="8" y="205" width="33" height="15.666666666666657"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <color key="textColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -140,7 +144,7 @@
                     <constraint firstAttribute="trailing" secondItem="Vhj-7R-C3L" secondAttribute="trailing" id="VIU-Np-KVP"/>
                     <constraint firstItem="Vhj-7R-C3L" firstAttribute="leading" secondItem="1sj-HC-Dlr" secondAttribute="leading" id="Zab-TW-Zf3"/>
                     <constraint firstItem="Vhj-7R-C3L" firstAttribute="top" secondItem="WqS-NL-D4v" secondAttribute="bottom" constant="8" id="asa-C5-Nxd"/>
-                    <constraint firstItem="Vhj-7R-C3L" firstAttribute="top" secondItem="Qus-iH-a3n" secondAttribute="bottom" id="bYZ-UK-swI"/>
+                    <constraint firstItem="Vhj-7R-C3L" firstAttribute="top" secondItem="Qus-iH-a3n" secondAttribute="bottom" id="cnp-4V-1d0"/>
                     <constraint firstAttribute="trailing" secondItem="Qus-iH-a3n" secondAttribute="trailing" id="iOq-QK-Zgr"/>
                     <constraint firstItem="WqS-NL-D4v" firstAttribute="leading" secondItem="1sj-HC-Dlr" secondAttribute="leading" constant="8" id="iy7-mL-lg8"/>
                     <constraint firstAttribute="bottom" secondItem="Vhj-7R-C3L" secondAttribute="bottom" id="sV0-fV-kfI"/>


### PR DESCRIPTION
## #️⃣ Related Issues

close #81 

## 📝 Task Details

* 북마크 및 재생 기록 상세 보기 화면에서 네비게이션 바 오른쪽 버튼 숨기기 및 각 화면의 셀 패딩 및 컨텐츠 오토 레이아웃 수치 수정
* 셀에서 비디오 및 썸네일을 클릭하면 비디오 플레이어가 나타나도록 코드 구현 (비디오 캐시 X)

> 비디오를 다운로드하고, 파일을 캐시 폴더로 옮기는 과정에서 계속 오류가 발생하네요. 빨리 해결해볼게요...

### Screenshot (Optional)

| 1 | 2 |
| :-:  | :-: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-13 at 17 10 33](https://github.com/user-attachments/assets/3f124d55-6dcd-4882-9046-98fe34d25d85)   | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-13 at 17 10 38](https://github.com/user-attachments/assets/7b9f80c6-0792-4b2f-bbec-2d78d55b6db2) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-13 at 17 10 44](https://github.com/user-attachments/assets/c4122b15-f658-4d64-82e4-1f328ae782ff) | ![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-06-13 at 17 11 45](https://github.com/user-attachments/assets/4ff1b645-261c-4981-8cb6-eb9f921e2a69) |
| ![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-06-13 at 17 11 50](https://github.com/user-attachments/assets/86bec3f4-28e4-47c7-87f0-5451ccf7c178) | ![Simulator Screenshot - iPad Air 11-inch (M3) - 2025-06-13 at 17 11 54](https://github.com/user-attachments/assets/48c12e72-2229-452e-836e-230a4f06f8df) |

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
