### PR TITLE
fix: 모달 뷰 상단 패딩 문제 해결을 위해 NavigationController로 래핑

### DIFF
--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -190,8 +190,9 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
             case .interests:
                 let storyboard = UIStoryboard(name: "SelectedTagsViewController", bundle: nil)
                 if let interestVC = storyboard.instantiateViewController(withIdentifier: "SelectedTagsViewController") as? SelectedTagsViewController {
-                    interestVC.modalPresentationStyle = .automatic
-                    present(interestVC, animated: true)
+                    let nav = UINavigationController(rootViewController: interestVC)
+                    nav.modalPresentationStyle = .automatic
+                    present(nav, animated: true)
                 }
                 break
             case .none:


### PR DESCRIPTION
## #️⃣ Related Issues

close #118 

## 📝 Task Details

- `SelectedTagsViewController`를 `UINavigationController`로 감싸서 모달로 표시되었을 때 자동으로 상단 safe area에 맞춰 정렬되도록 수정 

### Screenshot (Optional)
- 전 
   <img src="https://github.com/user-attachments/assets/3e7df0b4-e91e-45c3-ab4a-a45f8f6ebec8" width="150"/>

- 후
   <img src="https://github.com/user-attachments/assets/757aaca1-6e04-4f6f-ae1c-80dc769577e5" width="150"/>
