### PR TITLE
fix: `이미 존재하는 재생 목록입니다.` 토스트 메시지를 영어로 수정, `ContentUnavailableView`의 중앙 이미지의 크기 비율 조정, 북마크 화면의 Playback 섹션에서 그룹(아이템) 간 간격이 너무 큰 문제 수정

### DIFF
--- a/Media/Core/Common/ContentUnavailableView/ContentUnavailableView.swift
+++ b/Media/Core/Common/ContentUnavailableView/ContentUnavailableView.swift
@@ -12,14 +12,33 @@ final class ContentUnavailableView: NibView {
     /// 사용자에게 콘텐츠가 없음을 나타내는 이미지를 표시하는 뷰입니다.
     @IBOutlet weak var imageView: UIImageView!
     
+    @IBOutlet weak var imageWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var imageHeightConstraint: NSLayoutConstraint!
+
     /// 표시할 이미지 리소스를 나타내는 속성입니다.
     /// 설정 시 자동으로 `imageView`의 이미지를 업데이트합니다.
     var imageResource: ImageResource = .noVideos {
         didSet { imageView.image = UIImage(resource: imageResource) }
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         loadFromNib(owner: self)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let viewWidth = self.bounds.width
+        let viewHeight = self.bounds.height
+
+        if traitCollection.horizontalSizeClass == .compact {
+            imageWidthConstraint.constant = viewWidth * 0.75
+            imageHeightConstraint.constant = viewHeight * 0.75
+        } else {
+            imageWidthConstraint.constant = viewWidth * 0.5
+            imageHeightConstraint.constant = viewHeight * 0.5
+
+        }
     }
 }

--- a/Media/Core/Common/ContentUnavailableView/ContentUnavailableView.xib
+++ b/Media/Core/Common/ContentUnavailableView/ContentUnavailableView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -10,7 +10,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ContentUnavailableView" customModule="Media" customModuleProvider="target">
             <connections>
+                <outlet property="imageHeightConstraint" destination="edO-vb-aOZ" id="Ayi-VL-Zee"/>
                 <outlet property="imageView" destination="q05-0Y-AYY" id="BV1-F3-pxj"/>
+                <outlet property="imageWidthConstraint" destination="h94-CJ-XWH" id="N4F-NZ-XcC"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Media/Presentation/Bookmark/BookmarkViewController.swift
+++ b/Media/Presentation/Bookmark/BookmarkViewController.swift
@@ -442,7 +442,7 @@ extension BookmarkViewController {
                     )
                     self.coreDataService.insert(newPlaylist)
                 } else {
-                    Toast.makeToast("이미 존재하는 재생 목록 이름입니다.").present()
+                    Toast.makeToast("A playlist with this name already exists.").present()
                 }
             } onCancel: { _ in }
     }

--- a/Media/Presentation/Bookmark/Section/BookmarkSection.swift
+++ b/Media/Presentation/Bookmark/Section/BookmarkSection.swift
@@ -77,7 +77,6 @@ extension Bookmark.SectionType {
             heightDimension: .fractionalHeight(1.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
 
         let groupWidthDimension: NSCollectionLayoutDimension = environment.isHorizontalSizeClassCompact
         ? .fractionalWidth(0.9) : .fractionalWidth(0.42)
@@ -91,7 +90,6 @@ extension Bookmark.SectionType {
             layoutSize: groupSize,
             subitems: [item]
         )
-        group.interItemSpacing = .flexible(10)
         group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 20, trailing: 0)
 
         let headerSize = NSCollectionLayoutSize(
@@ -106,8 +104,7 @@ extension Bookmark.SectionType {
         header.pinToVisibleBounds = true
 
         let section = NSCollectionLayoutSection(group: group)
-        section.interGroupSpacing = 12
-        section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
+        section.orthogonalScrollingBehavior = .groupPaging
         section.boundarySupplementaryItems = [header]
 
         return section


### PR DESCRIPTION
## #️⃣ Related Issues

close #120 
close #136 
close #137

## 📝 Task Details

* `이미 존재하는 재생 목록입니다.` 토스트 메시지를 영어로 수정 (홈 화면과 동일하게 수정)
* `ContentUnavailableView`의 중앙 이미지의 크기 비율 조정 (아이폰 0.75, 아이패드 0.5)
* 북마크 화면의 Playback 섹션에서 그룹(아이템) 간 간격이 너무 큰 문제 수정

### Screenshot (Optional)

| 1 | 2 |
| :--: | :--: |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 15 57](https://github.com/user-attachments/assets/b4473264-dd77-454f-8d13-42c99cb3c78a) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 15 51](https://github.com/user-attachments/assets/08cef307-e15c-46bf-9c57-64b4049eb4cd) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-15 at 12 22 38](https://github.com/user-attachments/assets/d4e6619c-d0e5-4153-8cd8-51b113b2fdfa) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 15 34](https://github.com/user-attachments/assets/4d26fc8f-8e84-42c1-a37e-513bd39e56c0) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 15 45](https://github.com/user-attachments/assets/21c6546d-068a-467f-b602-48d1970b03c6) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-06-16 at 11 15 21](https://github.com/user-attachments/assets/444c115d-f72e-4afe-97ef-f8338879ba8a) |
