### PR TITLE
fix: 검색 테이블 뷰 하단에 그림자 추가, 검색 끝나면 스크롤 할 때 키보드 &검색 테이블 뷰 사라지도록 변경 등

### DIFF
--- a/Media/Model/API/Category.swift
+++ b/Media/Model/API/Category.swift
@@ -29,7 +29,12 @@ enum Category: String, CaseIterable {
     case buildings
     case business
     case music
-    
+
+    var displayName: String {
+        return rawValue.prefix(1).uppercased()
+        + rawValue.dropFirst()
+    }
+
     var symbolImage: UIImage? {
         switch self {
         case .backgrounds:

--- a/Media/Presentation/Search/SearchFilterViewController.swift
+++ b/Media/Presentation/Search/SearchFilterViewController.swift
@@ -199,7 +199,7 @@ extension SearchFilterViewController: UICollectionViewDataSource {
 
             let target = categories[indexPath.item]
             cell.defaultCellConfigure()
-            cell.categoryLabel.text = target.rawValue
+            cell.categoryLabel.text = target.displayName
 
             return cell
         case filterOrderCollectionView:

--- a/Media/Presentation/Search/SearchResultViewController.swift
+++ b/Media/Presentation/Search/SearchResultViewController.swift
@@ -632,6 +632,8 @@ extension SearchResultViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let keyword = searchBar.text, !keyword.isEmpty else { return }
 
+        let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+
         // 키보드 내리기
         searchBar.resignFirstResponder()
 
@@ -640,13 +642,13 @@ extension SearchResultViewController: UISearchBarDelegate {
 
         //검색 기록 저장
         do {
-            try recordManager.save(query: keyword)
+            try recordManager.save(query: trimmed)
         } catch {
             print(error)
         }
         loadRecentSearches()
 
-        self.keyword = keyword
+        self.keyword = trimmed
         self.activityIndicator.startAnimating()
         self.videoCollectionView.isHidden = true
 

--- a/Media/Presentation/Search/SearchResultViewController.swift
+++ b/Media/Presentation/Search/SearchResultViewController.swift
@@ -79,13 +79,13 @@ final class SearchResultViewController: StoryboardViewController {
     /// 서치 결과 뷰에서 서치를 시작할 때 나오는 생략된 서치 뷰
     private lazy var recentSearchContainerView: UIView = {
         let view = UIView()
-        view.backgroundColor = .clear
-        view.layer.shadowColor = UIColor.tagSelected.cgColor
-        view.layer.shadowOpacity = 0.1
-        view.layer.shadowRadius = 4
-        view.clipsToBounds = true
-        view.layer.cornerRadius = 16
-        view.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        view.backgroundColor = UIColor.background
+
+        view.layer.shadowColor = UIColor.label.cgColor
+        view.layer.shadowOpacity = 0.2
+        view.layer.shadowRadius = 2
+        view.layer.shadowOffset = .init(width: 0, height: 4)
+        view.clipsToBounds = false
 
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false

--- a/Media/Presentation/Search/SearchResultViewController.swift
+++ b/Media/Presentation/Search/SearchResultViewController.swift
@@ -571,7 +571,12 @@ extension SearchResultViewController: UICollectionViewDataSource {
     }
 }
 
-extension SearchResultViewController: UICollectionViewDelegate {
+extension SearchResultViewController: UICollectionViewDelegate, UIScrollViewDelegate {
+    // 스크롤 시작 시 호출 메서드
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        view.endEditing(true)
+        hideRecentSearches()
+    }
 }
 
 extension SearchResultViewController: UICollectionViewDelegateFlowLayout {

--- a/Media/Presentation/Search/SearchViewController.swift
+++ b/Media/Presentation/Search/SearchViewController.swift
@@ -143,6 +143,8 @@ final class SearchViewController: StoryboardViewController {
         records = (try? recordManager.fetchRecent(limit: 20)) ?? []
         if !records.isEmpty {
             placeholderImageView.isHidden = true
+        } else {
+            placeholderImageView.isHidden = false
         }
         searchTableView.reloadData()
     }
@@ -225,12 +227,14 @@ extension SearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let target = records[indexPath.row]
 
+        let trimmed = target.query?.trimmingCharacters(in: .whitespacesAndNewlines)
+
         let storyboard = UIStoryboard(name: "SearchResultViewController", bundle: nil)
         if let searchResultVC = storyboard.instantiateViewController(withIdentifier: "SearchResultViewController") as? SearchResultViewController {
-            searchResultVC.keyword = target.query!
+            searchResultVC.keyword = trimmed
             // 검색 기록 저장
             do {
-                try recordManager.save(query: target.query!)
+                try recordManager.save(query: trimmed!)
             } catch {
                 print("Search Record save error:", error)
             }
@@ -259,6 +263,13 @@ extension SearchViewController: UITableViewDelegate {
 
                         self.records.remove(at: indexPath.row)
                         tableView.deleteRows(at: [indexPath], with: .automatic)
+
+                        if !self.records.isEmpty {
+                            self.placeholderImageView.isHidden = true
+                        } else {
+                            self.placeholderImageView.isHidden = false
+                        }
+
                         completion(true)
                     } catch {
                         print("삭제 실패:", error)
@@ -287,9 +298,11 @@ extension SearchViewController: UISearchBarDelegate {
         // 키보드 내리기
         searchBar.resignFirstResponder()
 
+        let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+
         // 검색 기록 저장
         do {
-            try recordManager.save(query: keyword)
+            try recordManager.save(query: trimmed)
         } catch {
             print("Search Record save error:", error)
         }
@@ -301,7 +314,7 @@ extension SearchViewController: UISearchBarDelegate {
             identifier: "SearchResultViewController"
         ) as? SearchResultViewController {
             // 검색어 전달
-            searchResultVC.keyword = keyword
+            searchResultVC.keyword = trimmed
             navigationController?.pushViewController(searchResultVC, animated: true)
         }
     }

--- a/Media/Presentation/Search/SearchViewController.swift
+++ b/Media/Presentation/Search/SearchViewController.swift
@@ -57,6 +57,7 @@ final class SearchViewController: StoryboardViewController {
         super.viewWillAppear(animated)
 
         loadRecentSearches()
+        reloadSavedFilters()
     }
 
     override func setupHierachy() {

--- a/Media/Presentation/Search/TVCell/SearchTableViewCell.xib
+++ b/Media/Presentation/Search/TVCell/SearchTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="pbh-xb-l2t">
-                        <rect key="frame" x="0.0" y="0.0" width="409" height="40"/>
+                        <rect key="frame" x="8" y="0.0" width="393" height="40"/>
                         <subviews>
                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mGh-I5-y6M">
                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -33,14 +33,14 @@
                                 <state key="normal" image="magnifyingglass" catalog="system"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i14-bZ-TtP">
-                                <rect key="frame" x="48" y="0.0" width="313" height="40"/>
+                                <rect key="frame" x="48" y="0.0" width="297" height="40"/>
                                 <color key="tintColor" name="MainLabel"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MjU-h9-1yh">
-                                <rect key="frame" x="369" y="0.0" width="40" height="40"/>
+                                <rect key="frame" x="353" y="0.0" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="MjU-h9-1yh" secondAttribute="height" multiplier="1:1" id="VRa-Qy-wgt"/>
                                     <constraint firstAttribute="height" constant="40" id="hYY-9a-mIo"/>
@@ -58,9 +58,9 @@
                 <color key="backgroundColor" name="Background"/>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="pbh-xb-l2t" secondAttribute="bottom" id="8YK-gF-sTp"/>
-                    <constraint firstItem="pbh-xb-l2t" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="FVg-c2-ExA"/>
+                    <constraint firstItem="pbh-xb-l2t" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="FVg-c2-ExA"/>
                     <constraint firstItem="pbh-xb-l2t" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="ePm-EJ-SlF"/>
-                    <constraint firstAttribute="trailing" secondItem="pbh-xb-l2t" secondAttribute="trailing" id="m72-VN-HxV"/>
+                    <constraint firstAttribute="trailing" secondItem="pbh-xb-l2t" secondAttribute="trailing" constant="8" id="m72-VN-HxV"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
## #️⃣ Related Issues

>  #142
#144 
#147 
 
## 📝 Task Details

- 검색 테이블 뷰 하단에 그림자 추가
- 검색 끝나면 스크롤 할 때 키보드 &검색 테이블 뷰 사라지도록 변경
- 필터를 빼면 필터 뱃지 상태 동기화(숫자 제거)
- 카테고리 필터 첫글자를 대문자로 수정

### Screenshot (Optional)

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 31 25](https://github.com/user-attachments/assets/b9e70239-bfda-4d2a-9246-543a538a66db)
![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 11 31 18](https://github.com/user-attachments/assets/788e6273-819f-4211-8fd5-a4f7d26b7d55)
