### PR TITLE
fix: 설정-취향 Selected 버튼 누르면 시트가 자동으로 닫히도록

### DIFF
--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -73,6 +73,16 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
         
         // 커스텀 스위치 셀 등록
         tableView.register(SwitchTableViewCell.nib, forCellReuseIdentifier: SwitchTableViewCell.id)
+        
+        // interests 셀 클릭 시 뜨는 모달을 닫기 위한 작업
+        // 'didSelectedCategories'이라는 Notification이 발생하면
+        // 'didReceiveSelectedCategories' 메서드를 호출
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveSelectedCategories),
+            name: .didSelectedCategories,
+            object: nil
+        )
     }
     
     /// 프로필 수정 화면으로 이동 전 사용자 정보 전달
@@ -89,6 +99,15 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
             editVC.editType = .email
             editVC.delegate = self
             editVC.currentText = userDefaults.userEmail ?? ""
+        }
+    }
+    
+    // MARK: - Notification
+    
+    @objc private func didReceiveSelectedCategories(_ notification: Notification) {
+        // 띄운 모달이 있으면 닫기
+        if let presented = self.presentedViewController {
+            presented.dismiss(animated: true)
         }
     }
     


### PR DESCRIPTION
## #️⃣ Related Issues

close #130 

## 📝 Task Details

- `interests` 셀 선택 시 표시되는 모달에서 
카테고리 선택 완료 시 모달이 자동 종료되도록 `NotificationCenter` 추가

### Screenshot (Optional)
![무제 2](https://github.com/user-attachments/assets/d0035793-647f-4805-8971-04401daca084)
