### PR TITLE
[Feat] 홈에서 태그값누르면 scroll to item 구현

### DIFF
--- a/Media/Presentation/Home/HomeViewController.swift
+++ b/Media/Presentation/Home/HomeViewController.swift
@@ -633,6 +633,8 @@ extension HomeViewController: UICollectionViewDelegate {
             selectedCategoryIndex = indexPath.item
             // 카테고리 컬렉션뷰 다시 그리기 (선택 상태 반영)
             categoryCollectionView.reloadData()
+            // 선택된 셀로 스크롤
+            categoryCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
             // 맨 위로 스크롤
             videoCollectionView.setContentOffset(.zero, animated: true)
             // 선택한 카테고리에 맞춰 비디오 재요청(초기화)
@@ -708,6 +710,28 @@ extension HomeViewController: UICollectionViewDataSource {
                     case .none:
                         self.addHistoryVideo(video)
                     }
+                }
+            }
+
+            cell.onTagTap = { [weak self] tag in
+                guard let self = self else { return }
+
+                // 본인 인덱스는 제외
+                let currentIndex = indexPath.item
+
+                // 본인 인덱스 제외 첫번째 영상찾기
+                if let index = self.videos.enumerated().first(where: { offset, hit in
+                    guard offset != currentIndex else { return false }
+                    let tags = hit.tags
+                        .split(separator: ",")
+                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    return tags.contains(tag.lowercased())
+                })?.offset {
+                    let indexPath = IndexPath(item: index, section: 0)
+                    self.videoCollectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: true)
+                    Toast.makeToast("Found tag: '\(tag)'", systemName: "lightbulb.max.fill").present()
+                } else {
+                    Toast.makeToast("No Found tag: '\(tag)'", systemName: "questionmark.circle").present()
                 }
             }
 

--- a/Media/Presentation/Home/VideoCell/VideoCell.swift
+++ b/Media/Presentation/Home/VideoCell/VideoCell.swift
@@ -31,6 +31,15 @@ final class VideoCell: UICollectionViewCell, NibLodable {
 
     var onThumbnailTap: (() -> Void)?
 
+    var onTagTap: ((String) -> Void)?
+
+    // Scroll To Item
+    @objc private func tagTapped() {
+        guard let tagText = tagLabel.text else { return }
+
+        onTagTap?(tagText)
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -65,6 +74,10 @@ final class VideoCell: UICollectionViewCell, NibLodable {
         thumbnailImage.addGestureRecognizer(tapGesture)
         
         ellipsisButton.showsMenuAsPrimaryAction = true
+
+        tagLabel.isUserInteractionEnabled = true
+        let tagTapGesture = UITapGestureRecognizer(target: self, action: #selector(tagTapped))
+        tagLabel.addGestureRecognizer(tagTapGesture)
     }
 
     @objc private func thumbnailTapped() {


### PR DESCRIPTION
[Fix] 카테고리 셀 터치하면 자동스크롤로 수정
[Feat] 홈에서 태그값누르면 scroll to item 구현 토스트까지 추가
#140 
![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 16 51 50](https://github.com/user-attachments/a
![Simulator Screenshot - iPhone 16 Pro - 2025-06-16 at 16 51 41](https://github.com/user-attachments/assets/a2d14e5f-7c77-4aa1-b1cd-ea3ef36aaf64)
ssets/3b351446-9f1c-4a5d-8752-f20446398a48)

## #️⃣ Related Issues

> ex) #IssueNumber, #IssueNumber

## 📝 Task Details

> Please briefly describe what was worked on in this PR (Images can be attached).

### Screenshot (Optional)

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
