### PR TITLE
fix: 비디오 퀄리티 변경 시 섹션 사이즈 변경되는 버그

### DIFF
--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -246,9 +246,11 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
             for quality in VideoQuality.allCases {
                 let action = UIAlertAction(title: quality.rawValue, style: .default) { [weak self] _ in
                     guard let self = self else { return }
+                    
                     self.currentVideoQuality = quality
                     self.videoQualityLabel.text = quality.rawValue
-                    tableView.reloadRows(at: [indexPath], with: .none)
+                    
+                    tableView.reloadData()
                 }
                 alert.addAction(action)
             }


### PR DESCRIPTION
## #️⃣ Related Issues

close #177 

## 📝 Task Details

- 기존: 특정 셀만 업데이트하기 위해 `reloadRows`를 사용
- 문제: 셀 내부 내용(예: 텍스트 길이)에 따라 셀 높이가 달라질 수 있는 구조에서는 예상치 못한 레이아웃 문제 발생 
  - `reloadRows`는 셀의 높이나 레이아웃이 바뀌지 않는다는 전제하에 작동하기 때문에 
   동적으로 높이가 변하는 셀을 리로드할 경우 간격이 어긋나거나 줄바꿈이 적용되지 않는 등 레이아웃이 깨질 수 있다고 함
- 해결: 전체를 다시 렌더링하는 `reloadData`로 변경하여 셀 높이 및 전체 레이아웃이 정상적으로 계산되도록 변경


### Screenshot (Optional)
   <img src="https://github.com/user-attachments/assets/8ffa7a5c-b525-4fa1-a8a2-79cf4a774335" width="150"/>