### PR TITLE
fix: 비디오 퀄리티 데이터 Userdefault에 저장이 제대로 안되는 버그

### DIFF
--- a/Media/Application/SceneDelegate.swift
+++ b/Media/Application/SceneDelegate.swift
@@ -24,8 +24,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        let isDark = UserDefaults.standard.bool(forKey: "isDarkMode")
-        window.overrideUserInterfaceStyle = isDark ? .dark : .light
+        let isDarkMode = UserDefaultsService.shared.isDarkMode
+        window.overrideUserInterfaceStyle = isDarkMode ? .dark : .light
         
         let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
         let onboardingStoryboard = UIStoryboard(name: "OnBoardingOnBoardingViewController", bundle: nil)
@@ -43,20 +43,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window = window
         window.makeKeyAndVisible()
-    }
-
-//    func sceneDidDisconnect(_ scene: UIScene) {
-//    }
-//
-//    func sceneDidBecomeActive(_ scene: UIScene) {
-//    }
-//    
-    /// 사용자 설정에 따라 라이트 / 다크 모드를 적용
-    private func applyUserInterfaceStyle(from windowScene: UIWindowScene) {
-        let isDark = UserDefaults.standard.bool(forKey: "isDarkMode")
-        if let window = windowScene.windows.first {
-            window.overrideUserInterfaceStyle = isDark ? .dark : .light
-        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/Media/Infrastructure/Storage/UserDefaults/UserDefaultsKeys.swift
+++ b/Media/Infrastructure/Storage/UserDefaults/UserDefaultsKeys.swift
@@ -50,6 +50,10 @@ extension UserDefaultsKeys {
     /// 기본값은 `Medium`입니다.
     var videoQuality: UserDefaultsKey<String> {
         UserDefaultsKey(name: "video_quality", defaultValue: VideoQuality.medium.rawValue)
-
+    }
+    /// 다크 모드 설정을 저장하는 키입니다.
+    /// 기본값은 `false`입니다.
+    var isDarkMode: UserDefaultsKey<Bool> {
+        UserDefaultsKey(name: "isDarkMode", defaultValue: false)
     }
 }

--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -32,7 +32,10 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
     }
         
     /// 다크 모드 활성화 여부
-    var isDarkMode = false
+    var isDarkMode: Bool {
+        get { userDefaults.isDarkMode }
+        set { userDefaults.isDarkMode = newValue }
+    }
     
     /// 사용자 기본 설정을 관리하는 서비스
     let userDefaults = UserDefaultsService.shared
@@ -57,9 +60,6 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
         nameLabel.text = userDefaults.userName
         emailLabel.text = userDefaults.userEmail
         videoQualityLabel.text = userDefaults.videoQuality
-        
-        // 다크 모드 초기화
-        isDarkMode = UserDefaults.standard.bool(forKey: "isDarkMode")
         
         // 커스텀 스위치 셀 등록
         tableView.register(SwitchTableViewCell.nib, forCellReuseIdentifier: SwitchTableViewCell.id)
@@ -164,7 +164,6 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
             cell.onSwitchToggle = { [weak self] isOn in
                 guard let self = self else { return }
                 self.isDarkMode = isOn
-                UserDefaults.standard.set(isOn, forKey: "isDarkMode")
                 
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                    let window = windowScene.windows.first {

--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -59,8 +59,8 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
         // 사용자 정보 및 해상도 표시
         nameLabel.text = userDefaults.userName
         emailLabel.text = userDefaults.userEmail
-        videoQualityLabel.text = userDefaults.videoQuality
-        
+        videoQualityLabel.text = currentVideoQuality.rawValue
+
         // 커스텀 스위치 셀 등록
         tableView.register(SwitchTableViewCell.nib, forCellReuseIdentifier: SwitchTableViewCell.id)
         
@@ -237,7 +237,7 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
                     guard let self = self else { return }
                     
                     // 선택한 해상도를 UserDefaults에 저장
-                    UserDefaults.standard.set(quality.rawValue, forKey: "video_quality")
+                    self.currentVideoQuality = quality
                     
                     // UI 업데이트
                     self.videoQualityLabel.text = quality.rawValue
@@ -298,6 +298,21 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
             default:
                 break
             }
+        }
+    }
+}
+
+extension SettingsTableViewController {
+    /// UserDefaultsService에 저장된 비디오 해상도 문자열 값을
+    /// VideoQuality enum으로 변환하여 반환. 유효하지 않으면 기본값(.medium)을 반환
+    /// 저장 시에도 enum의 rawValue(String)를 UserDefaults에 저장
+    var currentVideoQuality: VideoQuality {
+        get {
+            let saved = userDefaults.videoQuality
+            return VideoQuality(rawValue: saved) ?? .medium
+        }
+        set {
+            userDefaults.videoQuality = newValue.rawValue
         }
     }
 }


### PR DESCRIPTION
## #️⃣ Related Issues

close #206 

## 📝 Task Details

- 비디오 해상도를 UserDefaultsService으로 저장하여 앱 재실행 시 비디오 해상도 설정이 유지되도록 수정 
- 라이트 / 다크 모드 상태를 UserDefaultsService으로 저장하여 앱 재실행 시 모드 설정이 유지되도록 수정 

### Screenshot (Optional)

- 비디오 해상도 
![1해상도](https://github.com/user-attachments/assets/b672d07c-df48-4d94-95d8-a8ec56641feb)
  - 실제 영상의 해상도도 설정의 해상도에 따라 잘 나옴
    <img width="861" alt="스크린샷 2025-06-17 오전 10 19 36" src="https://github.com/user-attachments/assets/4961cfe4-4144-4931-81e9-fcac50cf7381" />

- 라이트 / 다크 모드
![1다크모드](https://github.com/user-attachments/assets/34c9b554-94c1-457f-82d3-8abb776e09d8)


