### PR TITLE
 fix: 탭바 순서 변경하기(Interest-Library)

### DIFF
--- a/Media/Application/SceneDelegate.swift
+++ b/Media/Application/SceneDelegate.swift
@@ -11,14 +11,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     
-    /**
-     Scene이 앱에 연결될 때 호출되는 메서드
-     
-     탭바 컨트롤러의 외관과 각 탭의 아이콘, 타이틀을 설정함
-     - 탭바 배경색을 설정하고 불투명하게 구성
-     - 선택된/선택되지 않은 탭의 색상 지정
-     - 각 탭(Home, Library, Interest, Setting)의 일반 상태와 선택된 상태 이미지 설정
-     */
+    /// Scene이 앱에 연결될 때 호출되는 메서드
+    /// - 탭바 설정 및 다크모드 적용
+    /// - 온보딩 완료 여부에 따라 루트 뷰컨트롤러 설정
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
@@ -37,11 +32,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {}
     func sceneDidEnterBackground(_ scene: UIScene) {}
     
+    /// UserDefaults의 다크모드 설정에 따라 인터페이스 스타일을 적용
     private func applyUserInterfaceStyle(to window: UIWindow) {
         let isDarkMode = UserDefaultsService.shared.isDarkMode
         window.overrideUserInterfaceStyle = isDarkMode ? .dark : .light
     }
     
+    /// 온보딩 완료 여부에 따라 루트 뷰컨트롤러를 설정
+    /// - 완료된 경우: 메인 탭바 컨트롤러(MainVC)
+    /// - 미완료인 경우: 온보딩 네비게이션 컨트롤러(OnboardingVC)
     private func setRootViewController(into window: UIWindow) {
         let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
         let onboardingStoryboard = UIStoryboard(name: "OnBoardingOnBoardingViewController", bundle: nil)

--- a/Media/Application/SceneDelegate.swift
+++ b/Media/Application/SceneDelegate.swift
@@ -20,13 +20,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
      - 각 탭(Home, Library, Interest, Setting)의 일반 상태와 선택된 상태 이미지 설정
      */
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
+        self.window = window
+        
+        applyUserInterfaceStyle(to: window)
+        setRootViewController(into: window)
+
+        window.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneWillResignActive(_ scene: UIScene) {}
+    func sceneWillEnterForeground(_ scene: UIScene) {}
+    func sceneDidEnterBackground(_ scene: UIScene) {}
+    
+    private func applyUserInterfaceStyle(to window: UIWindow) {
         let isDarkMode = UserDefaultsService.shared.isDarkMode
         window.overrideUserInterfaceStyle = isDarkMode ? .dark : .light
-        
+    }
+    
+    private func setRootViewController(into window: UIWindow) {
         let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
         let onboardingStoryboard = UIStoryboard(name: "OnBoardingOnBoardingViewController", bundle: nil)
         
@@ -40,15 +56,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let nav = UINavigationController(rootViewController: onboardingVC)
             window.rootViewController = nav
         }
-        
-        self.window = window
-        window.makeKeyAndVisible()
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {}
-    func sceneDidBecomeActive(_ scene: UIScene) {}
-    func sceneWillResignActive(_ scene: UIScene) {}
-    func sceneWillEnterForeground(_ scene: UIScene) {}
-    func sceneDidEnterBackground(_ scene: UIScene) {}
 }
 

--- a/Media/Presentation/Home/HomeViewController.swift
+++ b/Media/Presentation/Home/HomeViewController.swift
@@ -33,11 +33,14 @@ final class HomeViewController: StoryboardViewController, NavigationBarDelegate 
         }
     }
 
+    private var isTabBarConfigured = false
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if let tabBar = self.tabBarController {
+        if !isTabBarConfigured, let tabBar = self.tabBarController {
             TabBarConfigurator.configure(tabBarController: tabBar)
+            isTabBarConfigured = true
         }
     }
     

--- a/Media/Presentation/Home/HomeViewController.swift
+++ b/Media/Presentation/Home/HomeViewController.swift
@@ -33,6 +33,14 @@ final class HomeViewController: StoryboardViewController, NavigationBarDelegate 
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if let tabBar = self.tabBarController {
+            TabBarConfigurator.configure(tabBarController: tabBar)
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Media/Presentation/Home/HomeViewController.swift
+++ b/Media/Presentation/Home/HomeViewController.swift
@@ -33,13 +33,19 @@ final class HomeViewController: StoryboardViewController, NavigationBarDelegate 
         }
     }
 
+    /// 탭바 외형 설정 여부를 나타내는 플래그
+    /// viewDidAppear가 여러 번 호출될 수 있으므로 중복 설정을 방지하기 위해 사용
     private var isTabBarConfigured = false
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        // 탭바가 아직 설정되지 않았고 상위에 UITabBarController가 존재할 경우
         if !isTabBarConfigured, let tabBar = self.tabBarController {
+            // 탭바 외형 구성 수행 (배경색, 아이콘 등)
             TabBarConfigurator.configure(tabBarController: tabBar)
+            
+            // 한 번만 설정되도록 플래그 설정
             isTabBarConfigured = true
         }
     }


### PR DESCRIPTION
## #️⃣ Related Issues

close #207 

## 📝 Task Details
- TabBar 설정 누락 이슈 수정
  - `SceneDelegate`에서 탭바 외형을 설정하던 기존 방식은 온보딩 분기와 무관하게 항상 적용하도록 하기엔 코드가 복잡해짐
  - `TabBarConfigurator.configure()` 호출을 `MainVC(Home)`의 `viewDidLoad()` 내부로 이동해 해결
  (중복 적용을 방지하기 위해 isTabBarConfigured 플래그 추가)
  - `SceneDelegate` 내부 코드 분리 리펙토링

### Screenshot (Optional)
   <img src="https://github.com/user-attachments/assets/16356c6a-552e-470a-bd7e-0582025e72f4" width="200"/>
   <img src="https://github.com/user-attachments/assets/2f962dc5-735f-492d-94ef-676c41fc3678" width="200"/>