### PR TITLE
fix: 설정 화면 알림창 디자인 변경하고 언어는 영어로 설정하기

### DIFF
--- a/Media/Presentation/Settings/SettingsTableViewController.swift
+++ b/Media/Presentation/Settings/SettingsTableViewController.swift
@@ -10,7 +10,7 @@ import MessageUI
 
 /// 앱의 설정 화면을 관리하는 테이블 뷰 컨트롤러
 /// 사용자 프로필 정보 / 비디오 해상도 설정 / 다크 모드 전환 / 피드백 이메일 전송 등의 기능을 포함함
-class SettingsTableViewController: UITableViewController, EditProfileDelegate, MFMailComposeViewControllerDelegate {
+class SettingsTableViewController: UITableViewController, EditProfileDelegate, MFMailComposeViewControllerDelegate, Alertable {
     /// 설정 화면의 섹션을 구분하는 열거형
     enum Section: Int, CaseIterable {
         case profile, videoQuality, modeFeedback
@@ -291,9 +291,11 @@ class SettingsTableViewController: UITableViewController, EditProfileDelegate, M
 
                     present(mailComposeVC, animated: true, completion: nil)
                 } else {
-                    let alert = UIAlertController(title: "메일 앱이 설정되지 않았습니다", message: "기기의 메일 설정을 확인해 주세요.", preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: "확인", style: .default))
-                    present(alert, animated: true)
+                    showAlert(
+                        title: "Mail App Not Set Up",
+                        message: "Please check your device's mail settings.",
+                        onPrimary: { _ in }
+                    )
                 }
             default:
                 break


### PR DESCRIPTION
## #️⃣ Related Issues

close #204 

## 📝 Task Details

- 기존 시스템 알림을 커스텀 알림(Alertable의 `showAlert`)으로 교체
- 알림창 문구를 영어로 통일

### Screenshot (Optional)
   <img src="https://github.com/user-attachments/assets/e04f0cb5-2e7b-46fb-b1c3-3128e1e7468c" width="200"/>

   <img src="https://github.com/user-attachments/assets/d4ae9437-e4b5-4eb3-831f-58660f2a2bd1" width="200"/>
