### PR TITLE
fix: 검색 필터화면에서 시트 뒷배경 어둡게 변경

### DIFF
--- a/Media/Presentation/Search/SearchFilterViewController.swift
+++ b/Media/Presentation/Search/SearchFilterViewController.swift
@@ -46,9 +46,11 @@ class SearchFilterViewController: StoryboardViewController {
     let userDefaults = UserDefaultsService.shared
 
     var onApply: (() -> Void)?
+    var onDismiss: (() -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
     }
 
     deinit {
@@ -62,6 +64,8 @@ class SearchFilterViewController: StoryboardViewController {
         }
         filterCategoryCVHeightConstraint.constant = 40
         filterCategoryCollectionView.allowsMultipleSelection = false
+
+        presentationController?.delegate = self
     }
 
     override func setupAttributes() {
@@ -306,3 +310,8 @@ extension SearchFilterViewController: UISheetPresentationControllerDelegate {
     }
 }
 
+extension SearchFilterViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        onDismiss?()
+    }
+}

--- a/Media/Presentation/Search/SearchResultViewController.swift
+++ b/Media/Presentation/Search/SearchResultViewController.swift
@@ -64,6 +64,8 @@ final class SearchResultViewController: StoryboardViewController {
         return Int(ceil(pages))
     }
 
+    private var dimmingView: UIView?
+
     /// 필터 갯수 표현 라벨입니다.
     private lazy var filterLabel: UILabel = {
         let	label = UILabel()
@@ -313,12 +315,16 @@ final class SearchResultViewController: StoryboardViewController {
             Toast.makeToast("Filter has been applied.", systemName: "slider.horizontal.3").present()
             self.reloadSavedFilters()
             self.changeStateOfFilterButton()
+            self.dimmingView?.removeFromSuperview()
+        }
+
+        vc.onDismiss = {
+            self.dimmingView?.removeFromSuperview()
         }
 
         vc.modalPresentationStyle = .pageSheet
 
         if let sheet = vc.sheetPresentationController {
-            //sheet.detents = [.medium(), .large()]
             sheet.detents = [
                 .medium(),
                 .custom{ context in
@@ -337,6 +343,12 @@ final class SearchResultViewController: StoryboardViewController {
             sheet.preferredCornerRadius = 20
             sheet.delegate = vc
         }
+
+        let dim = UIView(frame: view.bounds)
+        dim.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        dim.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(dim)
+        self.dimmingView = dim
 
         present(vc, animated: true)
     }

--- a/Media/Presentation/Search/SearchViewController.swift
+++ b/Media/Presentation/Search/SearchViewController.swift
@@ -35,6 +35,8 @@ final class SearchViewController: StoryboardViewController {
         }
     }()
 
+    private var dimmingView: UIView?
+
     //필터 갯수 표현 라벨
     private lazy var filterLabel: UILabel = {
         let label = UILabel()
@@ -167,17 +169,20 @@ final class SearchViewController: StoryboardViewController {
             Toast.makeToast("Filter has been applied.", systemName: "slider.horizontal.3").present()
             self.reloadSavedFilters()
             self.changeStateOfFilterButton()
+            self.dimmingView?.removeFromSuperview()
+        }
+
+        vc.onDismiss = {
+            self.dimmingView?.removeFromSuperview()
         }
 
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
-//            sheet.detents = [.medium(), .large()]
             sheet.detents = [
                 .medium(),
                 .custom{ context in
                     0.8 * context.maximumDetentValue
                 }
-
             ]
             sheet.selectedDetentIdentifier = .medium
 
@@ -190,6 +195,12 @@ final class SearchViewController: StoryboardViewController {
             sheet.preferredCornerRadius = 20
             sheet.delegate = vc
         }
+
+        let dim = UIView(frame: view.bounds)
+        dim.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        dim.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(dim)
+        self.dimmingView = dim
 
         present(vc, animated: true)
     }
@@ -343,3 +354,4 @@ extension SearchViewController: NavigationBarDelegate {
         showSheet()
     }
 }
+


### PR DESCRIPTION
## #️⃣ Related Issues

closed #211 

## 📝 Task Details

- fix: 검색 필터화면에서 시트 뒷배경 어둡게 변경

### Screenshot (Optional)
![Simulator Screenshot - iPhone 16 Pro - 2025-06-17 at 15 28 48](https://github.com/user-attachments/assets/6f8907a6-e0ec-4dd6-9ca8-d08a3fe787e7)

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
