### PR TITLE
fix: 취향 선택 카테고리 셀의 shadow opacity 제거 

### DIFF
--- a/Media/Presentation/SelectedCategory/SelectedTagsViewController.swift
+++ b/Media/Presentation/SelectedCategory/SelectedTagsViewController.swift
@@ -184,7 +184,6 @@ class SelectedTagsViewController: StoryboardViewController {
         
         // 그림자 설정
         cell.layer.shadowColor = UIColor.black.cgColor
-        cell.layer.shadowOpacity = selected ? 0.4 : 0.1
         cell.layer.shadowOffset = CGSize(width: 0, height: 2)
         cell.layer.shadowRadius = 5
         cell.layer.masksToBounds = false


### PR DESCRIPTION
- 셀의 shadow opacity를 제거하여 더 깔끔한 인상
- iPad 가로 모드에서 발생하던 그림자 잔상 이슈 해결

![Simulator Screenshot - iPad (10th generation) - 2025-06-17 at 17 11 43](https://github.com/user-attachments/assets/29793b56-0a6e-44ed-bc35-54b43c035cf7)
