### PR TITLE
fix: 누락된 PiP 모드 다시 추가

### DIFF
--- a/Media/Resources/Info.plist
+++ b/Media/Resources/Info.plist
@@ -21,5 +21,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>picture-in-picture</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## #️⃣ Related Issues

close #245 

## 📝 Task Details
`Info.plist`에 `picture-in-picture` 백그라운드 모드를 다시 추가 
- `iPhone`, `iPad`: 모두 PiP 버튼 정상 노출 및 동작 확인 완료
- `iPhone`: 백그라운드로 갔을 때 자동으로 PiP 모드가 동작하는 지 확인 완료 (iPad는 기본 지원)

### Screenshot (Optional)
- iPhone
   <img src="https://github.com/user-attachments/assets/23d76fa7-97a5-4723-85b9-2b3460dfdad6" width="150"/>
   <img src="https://github.com/user-attachments/assets/90e38228-9928-4b0c-af64-ff5c29760293" width="150"/>

- iPad
   <img src="https://github.com/user-attachments/assets/fa26a945-a4e2-4aa5-9558-ce2fcd1026d4" width="300"/>
   <img src="https://github.com/user-attachments/assets/aa0ad3ff-828a-4a4e-a2b8-e36de7f5fbf5" width="300"/>
