### PR TITLE
Fix: 온보딩 후 홈 진입 시 탭바 깜빡임 이슈 해결

### DIFF
--- a/Media/Application/SceneDelegate.swift
+++ b/Media/Application/SceneDelegate.swift
@@ -48,6 +48,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if UserDefaults.standard.seenOnboarding {
             // 앱 실행시 온보딩이 완료된 경우 바로 메인화면으로 이동
             let mainVC = mainStoryboard.instantiateViewController(withIdentifier: "MainVC")
+            
+            // 탭바 설정
+            if let tabBarVC = mainVC as? UITabBarController {
+                TabBarConfigurator.configure(tabBarController: tabBarVC)
+            }
+            
             window.rootViewController = mainVC
         } else {
             // 앱 실행시 온보딩이 아직 진행이 안됐으면 온보딩 화면으로 이동

--- a/Media/Presentation/Onboarding/OnBoardingTagsViewController.swift
+++ b/Media/Presentation/Onboarding/OnBoardingTagsViewController.swift
@@ -30,8 +30,14 @@ class OnBoardingTagsViewController: StoryboardViewController {
             
             UserDefaults.standard.seenOnboarding = true
             
-            vc.modalPresentationStyle = .fullScreen
-            self.navigationController?.setViewControllers([vc], animated: true)
+            // 탭바 설정
+            TabBarConfigurator.configure(tabBarController: vc)
+            
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let sceneDelegate = scene.delegate as? SceneDelegate {
+                sceneDelegate.window?.rootViewController = vc
+                sceneDelegate.window?.makeKeyAndVisible()
+            }
         }
     }
     


### PR DESCRIPTION
## 📝 Task Details

- 온보딩 후 홈화면으로 전환할 때 navigation stack만 교체하던 기존 방식을 제거하고
  `window`의 `rootViewController`를 직접 교체하도록 수정
- 탭바 설정(`TabBarConfigurator.configure`)은 `rootViewController` 설정 직전에 적용
(탭바 UI는 탭바 컨트롤러가 `rootViewController`로 등록되는 시점에 결정되어 해당 시점 전에 탭바 설정이 적용되어야 깜빡임 없이 렌더링 가능)
